### PR TITLE
add option to replace codes with long names in input data

### DIFF
--- a/ptxboa/api.py
+++ b/ptxboa/api.py
@@ -122,6 +122,7 @@ class PtxboaAPI:
                 scenario_data[column_name] = scenario_data[column_name].map(
                     mapping, na_action="ignore"
                 )
+            scenario_data = scenario_data.replace(np.nan, "")
 
         if user_data is not None:
             # TODO: modify values based on user_data

--- a/ptxboa/api.py
+++ b/ptxboa/api.py
@@ -67,6 +67,7 @@ class PtxboaAPI:
     def get_input_data(
         self,
         scenario: str,
+        long_names: bool = True,
         user_data: dict = None,
     ) -> dict:
         """Return scenario data.
@@ -85,6 +86,9 @@ class PtxboaAPI:
                 - '2040 (low)'
                 - '2040 (medium)'
                 - '2040 (high)'
+        long_names : bool, optional
+            if True, will replace the codes used internally with long names that are
+            used in the frontend.
         user_data : dict, optional
             user data that overrides scenario data
 
@@ -102,6 +106,22 @@ class PtxboaAPI:
             )
 
         scenario_data = self.data_scenarios[scenario].copy()
+
+        if long_names:
+            for dim in ["parameter", "process", "flow", "region", "country"]:
+                mapping = pd.Series(
+                    self.dims[dim][f"{dim}_name"].to_list(),
+                    index=self.dims[dim][f"{dim}_code"],
+                )
+                if dim not in ["region", "country"]:
+                    column_name = f"{dim}_code"
+                elif dim == "region":
+                    column_name = "source_region_code"
+                elif dim == "country":
+                    column_name = "target_country_code"
+                scenario_data[column_name] = scenario_data[column_name].map(
+                    mapping, na_action="ignore"
+                )
 
         if user_data is not None:
             # TODO: modify values based on user_data

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -69,22 +69,6 @@ class TestTemplate(unittest.TestCase):
         )
 
     def test_get_input_data_nan_consistency(self):
-        res = self.api.get_input_data("2030 (high)", long_names=False)
-        self.assertEqual(
-            set(res.columns),
-            set(
-                [
-                    "parameter_code",
-                    "process_code",
-                    "flow_code",
-                    "source_region_code",
-                    "target_country_code",
-                    "value",
-                    "unit",
-                    "source",
-                ]
-            ),
-        )
         # test nans are at same place
         changed_columns = [
             "parameter_code",

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,5 +1,6 @@
 # coding: utf-8
 import unittest
+import numpy as np
 
 from ptxboa.api import PtxboaAPI
 
@@ -46,11 +47,11 @@ class TestTemplate(unittest.TestCase):
         }
         self._test_api_call(settings)
 
-    def test_api_get_input_data(self):
+    def test_api_get_input_data_output_format(self):
         # test wrong scenario
         self.assertRaises(ValueError, self.api.get_input_data, scenario="invalid")
         # test output structure of data
-        res = self.api.get_input_data("2030 (high)")
+        res = self.api.get_input_data("2030 (high)", long_names=False)
         self.assertEqual(
             set(res.columns),
             set(
@@ -66,3 +67,33 @@ class TestTemplate(unittest.TestCase):
                 ]
             ),
         )
+
+    def test_get_input_data_nan_consistency(self):
+        res = self.api.get_input_data("2030 (high)", long_names=False)
+        self.assertEqual(
+            set(res.columns),
+            set(
+                [
+                    "parameter_code",
+                    "process_code",
+                    "flow_code",
+                    "source_region_code",
+                    "target_country_code",
+                    "value",
+                    "unit",
+                    "source",
+                ]
+            ),
+        )
+        # test nans are at same place
+        changed_columns = [
+            "parameter_code",
+            "process_code",
+            "flow_code",
+            "source_region_code",
+            "target_country_code",
+        ]
+        for scenario in ["2030 (low)", "2030 (medium)", "2030 (high)", "2040 (low)", "2040 (medium)", "2040 (high)"]:
+            left = self.api.get_input_data(scenario, long_names=False)[changed_columns].values == ""
+            right = self.api.get_input_data(scenario, long_names=True)[changed_columns].isna().values
+            self.assertTrue(np.all(left == right))

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -95,5 +95,5 @@ class TestTemplate(unittest.TestCase):
         ]
         for scenario in ["2030 (low)", "2030 (medium)", "2030 (high)", "2040 (low)", "2040 (medium)", "2040 (high)"]:
             left = self.api.get_input_data(scenario, long_names=False)[changed_columns].values == ""
-            right = self.api.get_input_data(scenario, long_names=True)[changed_columns].isna().values
+            right = self.api.get_input_data(scenario, long_names=True)[changed_columns].values == ""
             self.assertTrue(np.all(left == right))


### PR DESCRIPTION
hi @markushal, 
maybe still some minor issues here:

~~- missing values that are empty strings when `long_names=False` are returned as NaN. is that okay? Otherwise, I can replace Nans with empty strings again.~~

**Update:** Empty values are now empty strings and not Nans also for `long_names=True`

- if a parameter code/name pair is not defined in api.dims, the long name will also be NaN even if a code was there before. ~~We could check in a test that this is not happening~~ **Update:**: there is now a test that should cover this. 
