### PR TITLE
68 bug no cost output in app

### DIFF
--- a/app/ptxboa_functions.py
+++ b/app/ptxboa_functions.py
@@ -471,7 +471,7 @@ def remove_subregions(api: PtxboaAPI, df: pd.DataFrame, settings: dict):
     # do not show subregions:
     region_list_without_subregions = (
         api.get_dimension("region")
-        .loc[api.get_dimension("region")["subregion_code"].isna()]
+        .loc[api.get_dimension("region")["subregion_code"] == ""]
         .index.to_list()
     )
 

--- a/tests/test_ptxboa_functions.py
+++ b/tests/test_ptxboa_functions.py
@@ -42,7 +42,7 @@ class TestPtxboaFunctions(unittest.TestCase):
         # output is dataframe:
         self.assertIsInstance(df_out, pd.DataFrame)
 
-        # regions including subregions: 34
+        # regions without subregions: 34
         self.assertEqual(len(df_out), 34)
         # Argentina should be in:
         self.assertTrue("Argentina" in df_out["region_name"])

--- a/tests/test_ptxboa_functions.py
+++ b/tests/test_ptxboa_functions.py
@@ -1,0 +1,58 @@
+# -*- coding: utf-8 -*-
+"""Unittests for ptxboa_functions module."""
+
+import logging
+import unittest
+
+import pandas as pd
+
+import app.ptxboa_functions as pf
+from ptxboa.api import PtxboaAPI
+
+logging.basicConfig(
+    format="[%(asctime)s %(levelname)7s] %(message)s",
+    datefmt="%Y-%m-%d %H:%M:%S",
+    level=logging.INFO,
+)
+
+
+class TestPtxboaFunctions(unittest.TestCase):
+    def test_remove_subregions(self):
+        """Test remove_subregions function."""
+        settings = {
+            "region": "United Arab Emirates",
+            "country": "Germany",
+            "chain": "Methane (AEL)",
+            "res_gen": "PV tilted",
+            "scenario": "2040 (medium)",
+            "secproc_co2": "Direct Air Capture",
+            "secproc_water": "Sea Water desalination",
+            "transport": "Ship",
+            "ship_own_fuel": False,
+            "output_unit": "USD/t",
+        }
+        api = PtxboaAPI()
+        df_in = api.get_dimension("region")
+
+        # regions including subregions: 79
+        self.assertEqual(len(df_in), 79)
+
+        df_out = pf.remove_subregions(api, df_in, settings)
+
+        # output is dataframe:
+        self.assertIsInstance(df_out, pd.DataFrame)
+
+        # regions including subregions: 34
+        self.assertEqual(len(df_out), 34)
+        # Argentina should be in:
+        self.assertTrue("Argentina" in df_out["region_name"])
+        # Argentina (Buenos Aires) should be out:
+        self.assertFalse("Argentina (Buenos Aires)" in df_out["region_name"])
+
+        # if target country is also a source region, it needs to be removed
+        # from the source region list:
+
+        settings["country"] = "China"
+        df_out = pf.remove_subregions(api, df_in, settings)
+        self.assertEqual(len(df_out), 33)
+        self.assertFalse("China" in df_out["region_name"])


### PR DESCRIPTION
Hi guys, the reason why there was not costs data displayed in the app #68   was that the removal of subregions failed, because it tested for empty subregion codes in ``api.get_dimension("region"), and these changed from being NaN to now being empty strings. 

I adjusted the check in ``remove_subregions``, and the app is working fine now, but I wonder if this is how we want to keep it? 

I also added a unit test for the function, and i created a new python file for tests of the ``ptxboa_functions`` module. Is this the correct way of doing it?