### PR TITLE
105 move settings to session state

### DIFF
--- a/app/ptxboa_functions.py
+++ b/app/ptxboa_functions.py
@@ -38,38 +38,6 @@ def calculate_results_single(
     return res
 
 
-def calculate_results(api: PtxboaAPI, region_list: list = None) -> pd.DataFrame:
-    """Calculate results for source regions and one selected target country.
-
-    TODO: This function will eventually be replaced by ``calculate_results_list()``.
-
-    Parameters
-    ----------
-    api : :class:`~ptxboa.api.PtxboaAPI`
-        an instance of the api class
-    region_list : list or None
-        The regions for which the results are calculated. If None, all regions
-        available in the API will be used.
-
-    Returns
-    -------
-    pd.DataFrame
-        same format as for :meth:`~ptxboa.api.PtxboaAPI.calculate()`
-    """
-    res_list = []
-
-    if region_list is None:
-        region_list = api.get_dimension("region")["region_name"]
-
-    for region in region_list:
-        settings2 = st.session_state["settings"].copy()
-        settings2["region"] = region
-        res_single = calculate_results_single(api, settings2)
-        res_list.append(res_single)
-    res = pd.concat(res_list)
-    return res
-
-
 def calculate_results_list(
     api: PtxboaAPI,
     parameter_to_change: str,

--- a/app/ptxboa_functions.py
+++ b/app/ptxboa_functions.py
@@ -536,12 +536,6 @@ Switch to other tabs to explore data and results in more detail!
 
         create_infobox(context_data)
 
-    st.write("Chosen settings:")
-    st.write(st.session_state)
-
-    st.write("res_cost")
-    st.write(res_costs)
-
 
 def content_market_scanning(api: PtxboaAPI, res_costs: pd.DataFrame) -> None:
     """Create content for the "market scanning" sheet.
@@ -994,11 +988,6 @@ They also show the data for your country for comparison.
 
     # If there are user changes, display them:
     display_user_changes()
-
-    st.write("**Debug: Session state**")
-    st.write(
-        st.session_state
-    )  # FIXME this is debugging output, remove when it is not needed anymore
 
 
 def reset_user_changes():

--- a/app/ptxboa_functions.py
+++ b/app/ptxboa_functions.py
@@ -330,7 +330,9 @@ def create_world_map(api: PtxboaAPI, res_costs: pd.DataFrame):
     ]
 
     # remove subregions from deep dive countries (otherwise colorscale is not correct)
-    res_costs = remove_subregions(api, res_costs)
+    res_costs = remove_subregions(
+        api, res_costs, st.session_state["settings"]["country"]
+    )
 
     # Create custom hover text:
     custom_hover_data = res_costs.apply(
@@ -617,7 +619,7 @@ This sheet helps you to better evaluate your country's competitive position
     df_plot = df_plot.merge(distances, left_index=True, right_index=True)
 
     # do not show subregions:
-    df_plot = remove_subregions(api, df_plot)
+    df_plot = remove_subregions(api, df_plot, st.session_state["settings"]["country"])
 
     # create plot:
     [c1, c2] = st.columns([1, 5])
@@ -650,7 +652,7 @@ This sheet helps you to better evaluate your country's competitive position
     st.dataframe(df_plot, use_container_width=True, column_config=column_config)
 
 
-def remove_subregions(api: PtxboaAPI, df: pd.DataFrame):
+def remove_subregions(api: PtxboaAPI, df: pd.DataFrame, country_name: str):
     """Remove subregions from a dataframe.
 
     Parameters
@@ -658,7 +660,11 @@ def remove_subregions(api: PtxboaAPI, df: pd.DataFrame):
     api : :class:`~ptxboa.api.PtxboaAPI`
         an instance of the api class
 
-    df : pandas DataFrame with list of regions as index.
+    df : pd.DataFrame
+        pandas DataFrame with list of regions as index.
+
+    country_name : str
+        name of target country. Is removed from region list if it is also in there.
 
     Returns
     -------
@@ -672,8 +678,8 @@ def remove_subregions(api: PtxboaAPI, df: pd.DataFrame):
     )
 
     # ensure that target country is not in list of regions:
-    if st.session_state["settings"]["country"] in region_list_without_subregions:
-        region_list_without_subregions.remove(st.session_state["settings"]["country"])
+    if country_name in region_list_without_subregions:
+        region_list_without_subregions.remove(country_name)
 
     df = df.loc[region_list_without_subregions]
 
@@ -749,7 +755,9 @@ Data can be filterend and sorted.
             )
             st.dataframe(df_res, use_container_width=True, column_config=column_config)
 
-    res_costs_without_subregions = remove_subregions(api, res_costs)
+    res_costs_without_subregions = remove_subregions(
+        api, res_costs, st.session_state["settings"]["country"]
+    )
     display_costs(res_costs_without_subregions, "region", "Costs by region:")
 
     # Display costs by scenario:

--- a/ptxboa_streamlit.py
+++ b/ptxboa_streamlit.py
@@ -46,11 +46,11 @@ st.title("PtX Business Opportunity Analyzer :red[draft version, please do not qu
 api = st.cache_resource(PtxboaAPI)()
 
 # create sidebar:
-settings = pf.create_sidebar(api)
+pf.create_sidebar(api)
 
 # calculate results:
 res_costs = pf.calculate_results_list(
-    api, settings, "region", user_data=st.session_state["user_changes_df"]
+    api, "region", user_data=st.session_state["user_changes_df"]
 )
 
 # import context data:
@@ -58,24 +58,24 @@ cd = st.cache_resource(pf.import_context_data)()
 
 # dashboard:
 with t_dashboard:
-    pf.content_dashboard(api, res_costs, cd, settings)
+    pf.content_dashboard(api, res_costs, cd)
 
 with t_market_scanning:
-    pf.content_market_scanning(api, res_costs, settings)
+    pf.content_market_scanning(api, res_costs)
 
 with t_compare_costs:
-    pf.content_compare_costs(api, res_costs, settings)
+    pf.content_compare_costs(api, res_costs)
 
 with t_input_data:
-    pf.content_input_data(api, settings)
+    pf.content_input_data(api)
 
 with t_deep_dive_countries:
-    pf.content_deep_dive_countries(api, res_costs, settings)
+    pf.content_deep_dive_countries(api, res_costs)
 
 with t_country_fact_sheets:
-    pf.create_fact_sheet_demand_country(cd, settings["country"])
+    pf.create_fact_sheet_demand_country(cd)
     st.divider()
-    pf.create_fact_sheet_supply_country(cd, settings["region"])
+    pf.create_fact_sheet_supply_country(cd)
 
 with t_certification_schemes:
     pf.create_fact_sheet_certification_schemes(cd)

--- a/tests/test_ptxboa_functions.py
+++ b/tests/test_ptxboa_functions.py
@@ -20,7 +20,7 @@ logging.basicConfig(
 class TestPtxboaFunctions(unittest.TestCase):
     def test_remove_subregions(self):
         """Test remove_subregions function."""
-        st.session_state["settings"] = {
+        settings = {
             "region": "United Arab Emirates",
             "country": "Germany",
             "chain": "Methane (AEL)",
@@ -38,7 +38,7 @@ class TestPtxboaFunctions(unittest.TestCase):
         # regions including subregions: 79
         self.assertEqual(len(df_in), 79)
 
-        df_out = pf.remove_subregions(api, df_in)
+        df_out = pf.remove_subregions(api, df_in, settings["country"])
 
         # output is dataframe:
         self.assertIsInstance(df_out, pd.DataFrame)
@@ -53,8 +53,8 @@ class TestPtxboaFunctions(unittest.TestCase):
         # if target country is also a source region, it needs to be removed
         # from the source region list:
 
-        st.session_state["settings"]["country"] = "China"
-        df_out = pf.remove_subregions(api, df_in)
+        settings["country"] = "China"
+        df_out = pf.remove_subregions(api, df_in, settings["country"])
         self.assertEqual(len(df_out), 33)
         self.assertFalse("China" in df_out["region_name"])
 

--- a/tests/test_ptxboa_functions.py
+++ b/tests/test_ptxboa_functions.py
@@ -5,7 +5,6 @@ import logging
 import unittest
 
 import pandas as pd
-import streamlit as st
 
 import app.ptxboa_functions as pf
 from ptxboa.api import PtxboaAPI
@@ -57,29 +56,3 @@ class TestPtxboaFunctions(unittest.TestCase):
         df_out = pf.remove_subregions(api, df_in, settings["country"])
         self.assertEqual(len(df_out), 33)
         self.assertFalse("China" in df_out["region_name"])
-
-    def test_calculate_results_list(self):
-        """Test calculate_results_list function."""
-        st.session_state["settings"] = {
-            "region": "United Arab Emirates",
-            "country": "Germany",
-            "chain": "Methane (AEL)",
-            "res_gen": "PV tilted",
-            "scenario": "2040 (medium)",
-            "secproc_co2": "Direct Air Capture",
-            "secproc_water": "Sea Water desalination",
-            "transport": "Ship",
-            "ship_own_fuel": False,
-            "output_unit": "USD/t",
-        }
-        api = PtxboaAPI()
-
-        # old way of calculating results:
-        res_details = pf.calculate_results(api)
-        res_costs = pf.aggregate_costs(res_details)
-
-        # new way of calculating results:
-        res_by_region = pf.calculate_results_list(api, "region")
-
-        # assert that both ways yield identical results:
-        pd.testing.assert_frame_equal(res_costs, res_by_region)

--- a/tests/test_ptxboa_functions.py
+++ b/tests/test_ptxboa_functions.py
@@ -5,6 +5,7 @@ import logging
 import unittest
 
 import pandas as pd
+import streamlit as st
 
 import app.ptxboa_functions as pf
 from ptxboa.api import PtxboaAPI
@@ -19,7 +20,7 @@ logging.basicConfig(
 class TestPtxboaFunctions(unittest.TestCase):
     def test_remove_subregions(self):
         """Test remove_subregions function."""
-        settings = {
+        st.session_state["settings"] = {
             "region": "United Arab Emirates",
             "country": "Germany",
             "chain": "Methane (AEL)",
@@ -37,7 +38,7 @@ class TestPtxboaFunctions(unittest.TestCase):
         # regions including subregions: 79
         self.assertEqual(len(df_in), 79)
 
-        df_out = pf.remove_subregions(api, df_in, settings)
+        df_out = pf.remove_subregions(api, df_in)
 
         # output is dataframe:
         self.assertIsInstance(df_out, pd.DataFrame)
@@ -52,14 +53,14 @@ class TestPtxboaFunctions(unittest.TestCase):
         # if target country is also a source region, it needs to be removed
         # from the source region list:
 
-        settings["country"] = "China"
-        df_out = pf.remove_subregions(api, df_in, settings)
+        st.session_state["settings"]["country"] = "China"
+        df_out = pf.remove_subregions(api, df_in)
         self.assertEqual(len(df_out), 33)
         self.assertFalse("China" in df_out["region_name"])
 
     def test_calculate_results_list(self):
         """Test calculate_results_list function."""
-        settings = {
+        st.session_state["settings"] = {
             "region": "United Arab Emirates",
             "country": "Germany",
             "chain": "Methane (AEL)",
@@ -74,14 +75,11 @@ class TestPtxboaFunctions(unittest.TestCase):
         api = PtxboaAPI()
 
         # old way of calculating results:
-        res_details = pf.calculate_results(
-            api,
-            settings,
-        )
+        res_details = pf.calculate_results(api)
         res_costs = pf.aggregate_costs(res_details)
 
         # new way of calculating results:
-        res_by_region = pf.calculate_results_list(api, settings, "region")
+        res_by_region = pf.calculate_results_list(api, "region")
 
         # assert that both ways yield identical results:
         pd.testing.assert_frame_equal(res_costs, res_by_region)


### PR DESCRIPTION
I moved the ``settings`` dictionary to ``st.session_state["settings"]``. keep in mind that unittests do not work for functions that call ``st.session_state``. This is why I removed the legacy ``calculate_results`` function and the associated test. 

We should try to set up the streamlit testing framework #112

@joAschauer I hope these changes do not conflict with the work you are currently doing