### PR TITLE
reduce height of colorbar

### DIFF
--- a/app/plot_functions.py
+++ b/app/plot_functions.py
@@ -73,9 +73,11 @@ def create_world_map(api: PtxboaAPI, res_costs: pd.DataFrame):
 
     fig.update_layout(
         coloraxis_colorbar={"title": st.session_state["output_unit"]},  # colorbar
-        height=600,  # height of figure
         margin={"t": 20, "b": 20, "l": 20, "r": 20},  # reduce margin around figure
     )
+
+    # reduce height of the colorbar:
+    fig.update_layout(coloraxis_colorbar={"len": 0.5})
 
     # Set the hover template to use the custom data
     fig.update_traces(hovertemplate="%{customdata}<extra></extra>")  # Custom data


### PR DESCRIPTION
a mini PR. Streamlit does not scale down the height of the colorbar of the world map. By reducing its height, it looks slightly better on narrow screens. 