### PR TITLE
Feat/maps for input data

### DIFF
--- a/app/plot_functions.py
+++ b/app/plot_functions.py
@@ -141,6 +141,8 @@ def plot_input_data_on_map(
             "Wind-PV-Hybrid",
         ]
     custom_data_func_kwargs["unit"] = units[data_type]
+    custom_data_func_kwargs["data_type"] = data_type
+    custom_data_func_kwargs["map_variable"] = color_col
 
     input_data = subset_and_pivot_input_data(
         input_data=input_data,
@@ -306,14 +308,20 @@ def _set_map_layout(fig: go.Figure, title: str, colorbar_title: str) -> go.Figur
     return fig
 
 
-def _make_inputs_hoverdata(df, unit, float_precision):
-    custom_hover_data = df.apply(
-        lambda x: f"<b>{x.name}</b><br><br>"
-        + "<br>".join(
-            [f"<b>{col}</b>: {x[col]:.{float_precision}f}{unit}" for col in df.columns]
-        ),
-        axis=1,
-    )
+def _make_inputs_hoverdata(df, data_type, map_variable, unit, float_precision):
+    custom_hover_data = []
+    if data_type == "interest rate":
+        for idx, row in df.iterrows():
+            hover = f"<b>{idx} | {data_type} </b><br><br>{row['interest rate']}"
+            custom_hover_data.append(hover)
+    else:
+        for idx, row in df.iterrows():
+            hover = f"<b>{idx} | {data_type} </b><br>"
+            for i, v in zip(row.index, row):
+                hover += f"<br><b>{i}</b>: {v:.{float_precision}f}{unit}"
+                if i == map_variable:
+                    hover += " (displayed on map)"
+            custom_hover_data.append(hover)
     return [custom_hover_data]
 
 

--- a/app/ptxboa_functions.py
+++ b/app/ptxboa_functions.py
@@ -244,7 +244,7 @@ def display_and_edit_data_table(
         column_config_all = config_number_columns(df_tab, **column_config)
 
     # display data:
-    st.data_editor(
+    df_tab = st.data_editor(
         df_tab,
         use_container_width=True,
         key=key,

--- a/app/tab_deep_dive_countries.py
+++ b/app/tab_deep_dive_countries.py
@@ -87,7 +87,7 @@ They also show the data for your selected supply country or region for compariso
     st.subheader("Full load hours of renewable generation")
     c1, c2 = st.columns([2, 1], gap="large")
     with c1:
-        st.markdown("**Map of input data values**")
+        st.markdown("**Map**")
         if data_selection in ["full load hours", "CAPEX"]:
             map_parameter = st.selectbox(
                 "Show Parameter on Map", process_code, key="ddc_flh_map_parameter"
@@ -101,9 +101,7 @@ They also show the data for your selected supply country or region for compariso
             scope=ddc,
         )
         st.plotly_chart(fig, use_container_width=True)
-    with st.expander(f"**Region specific {data_selection} data**"):
-        # show data:
-        st.markdown("**Data:**")
+    with st.expander("**Data**"):
         df = display_and_edit_data_table(
             input_data=input_data,
             missing_index_name=missing_index_name,
@@ -117,6 +115,6 @@ They also show the data for your selected supply country or region for compariso
         )
     with c2:
         # create plot:
-        st.markdown("**Figure:**")
+        st.markdown("**Regional Distribution**")
         fig = px.box(df)
         st.plotly_chart(fig, use_container_width=True)

--- a/app/tab_deep_dive_countries.py
+++ b/app/tab_deep_dive_countries.py
@@ -44,10 +44,8 @@ They also show the data for your selected supply country or region for compariso
     fig_map = plot_costs_on_map(api, res_costs, scope=ddc, cost_component="Total")
     st.plotly_chart(fig_map, use_container_width=True)
 
-    # get input data:
-
+    st.subheader("Full load hours of renewable generation")
     input_data = api.get_input_data(st.session_state["scenario"])
-
     # filter data:
     # get list of subregions:
     region_list = (
@@ -56,51 +54,31 @@ They also show the data for your selected supply country or region for compariso
         .index.to_list()
     )
 
-    # TODO: implement display of total costs
-    list_data_types = ["full load hours"]
-    data_selection = st.radio(
-        "Select data type",
-        list_data_types,
-        horizontal=True,
-        key="sel_data_ddc",
-    )
-    if data_selection == "full load hours":
-        parameter_code = ["full load hours"]
-        process_code = [
-            "Wind Onshore",
-            "Wind Offshore",
-            "PV tilted",
-            "Wind-PV-Hybrid",
-        ]
-        x = "process_code"
-        missing_index_name = "parameter_code"
-        missing_index_value = "full load hours"
-        column_config = {"format": "%.0f h/a", "min_value": 0, "max_value": 8760}
+    parameter_code = ["full load hours"]
+    process_code = [
+        "Wind Onshore",
+        "Wind Offshore",
+        "PV tilted",
+        "Wind-PV-Hybrid",
+    ]
+    x = "process_code"
+    missing_index_name = "parameter_code"
+    missing_index_value = "full load hours"
+    column_config = {"format": "%.0f h/a", "min_value": 0, "max_value": 8760}
 
-    if data_selection == "total costs":
-        df = res_costs.copy()
-        df = res_costs.loc[region_list].rename({"Total": data_selection}, axis=1)
-        df = df.rename_axis("source_region_code", axis=0)
-        x = None
-        st.markdown("TODO: fix surplus countries in data table")
-
-    st.subheader("Full load hours of renewable generation")
     # in order to keep the figures horizontally aligned, we create two st.columns pairs
     # the columns are identified by c_{row}_{column}, zero indexed
     c_0_0, c_0_1 = st.columns([2, 1], gap="large")
     c_1_0, c_1_1 = st.columns([2, 1], gap="large")
     with c_0_0:
         st.markdown("**Map**")
-        if data_selection in ["full load hours", "CAPEX"]:
-            map_parameter = st.selectbox(
-                "Show Parameter on Map", process_code, key="ddc_flh_map_parameter"
-            )
-        else:
-            map_parameter = "interest rate"
+        map_parameter = st.selectbox(
+            "Show Parameter on Map", process_code, key="ddc_flh_map_parameter"
+        )
     with c_1_0:
         fig = plot_input_data_on_map(
             api=api,
-            data_type=data_selection,
+            data_type="full load hours",
             color_col=map_parameter,
             scope=ddc,
         )

--- a/app/tab_deep_dive_countries.py
+++ b/app/tab_deep_dive_countries.py
@@ -4,7 +4,7 @@ import pandas as pd
 import plotly.express as px
 import streamlit as st
 
-from app.plot_functions import plot_costs_on_map
+from app.plot_functions import plot_costs_on_map, plot_input_data_on_map
 from app.ptxboa_functions import display_and_edit_data_table
 from ptxboa.api import PtxboaAPI
 
@@ -84,8 +84,24 @@ They also show the data for your selected supply country or region for compariso
         x = None
         st.markdown("TODO: fix surplus countries in data table")
 
-    c1, c2 = st.columns(2, gap="medium")
-    with c2:
+    st.subheader("Full load hours of renewable generation")
+    c1, c2 = st.columns([2, 1], gap="large")
+    with c1:
+        st.markdown("**Map of input data values**")
+        if data_selection in ["full load hours", "CAPEX"]:
+            map_parameter = st.selectbox(
+                "Show Parameter on Map", process_code, key="ddc_flh_map_parameter"
+            )
+        else:
+            map_parameter = "interest rate"
+        fig = plot_input_data_on_map(
+            api=api,
+            data_type=data_selection,
+            color_col=map_parameter,
+            scope=ddc,
+        )
+        st.plotly_chart(fig, use_container_width=True)
+    with st.expander(f"**Region specific {data_selection} data**"):
         # show data:
         st.markdown("**Data:**")
         df = display_and_edit_data_table(
@@ -99,7 +115,7 @@ They also show the data for your selected supply country or region for compariso
             column_config=column_config,
             key_suffix="_ddc",
         )
-    with c1:
+    with c2:
         # create plot:
         st.markdown("**Figure:**")
         fig = px.box(df)

--- a/app/tab_deep_dive_countries.py
+++ b/app/tab_deep_dive_countries.py
@@ -85,8 +85,11 @@ They also show the data for your selected supply country or region for compariso
         st.markdown("TODO: fix surplus countries in data table")
 
     st.subheader("Full load hours of renewable generation")
-    c1, c2 = st.columns([2, 1], gap="large")
-    with c1:
+    # in order to keep the figures horizontally aligned, we create two st.columns pairs
+    # the columns are identified by c_{row}_{column}, zero indexed
+    c_0_0, c_0_1 = st.columns([2, 1], gap="large")
+    c_1_0, c_1_1 = st.columns([2, 1], gap="large")
+    with c_0_0:
         st.markdown("**Map**")
         if data_selection in ["full load hours", "CAPEX"]:
             map_parameter = st.selectbox(
@@ -94,6 +97,7 @@ They also show the data for your selected supply country or region for compariso
             )
         else:
             map_parameter = "interest rate"
+    with c_1_0:
         fig = plot_input_data_on_map(
             api=api,
             data_type=data_selection,
@@ -113,8 +117,8 @@ They also show the data for your selected supply country or region for compariso
             column_config=column_config,
             key_suffix="_ddc",
         )
-    with c2:
-        # create plot:
+    with c_0_1:
         st.markdown("**Regional Distribution**")
+    with c_1_1:
         fig = px.box(df)
         st.plotly_chart(fig, use_container_width=True)

--- a/app/tab_input_data.py
+++ b/app/tab_input_data.py
@@ -34,7 +34,7 @@ They also show the data for your country for comparison.
             """
         )
 
-    st.subheader("Region specific data:")
+    st.subheader("Region specific data")
     # get input data:
     input_data = api.get_input_data(
         st.session_state["scenario"],
@@ -89,7 +89,7 @@ They also show the data for your country for comparison.
 
     c1, c2 = st.columns([2, 1], gap="large")
     with c1:
-        st.markdown("**Map of input data values**")
+        st.markdown("**Map**")
         if data_selection in ["full load hours", "CAPEX"]:
             map_parameter = st.selectbox(
                 "Show Parameter on Map", process_code, key="input_data_map_parameter"
@@ -104,7 +104,7 @@ They also show the data for your country for comparison.
         )
         st.plotly_chart(fig, use_container_width=True)
 
-    with st.expander(f"**Region specific {data_selection} data**"):
+    with st.expander("**Data**"):
         df = display_and_edit_data_table(
             input_data=input_data_without_subregions,
             missing_index_name=missing_index_name,
@@ -117,12 +117,12 @@ They also show the data for your country for comparison.
         )
     with c2:
         # create plot:
-        st.markdown("**Value Distribution over Source regions:**")
+        st.markdown("**Regional Distribution**")
         fig = px.box(df)
         st.plotly_chart(fig, use_container_width=True)
 
     st.divider()
-    st.subheader("Data that is identical for all regions:")
+    st.subheader("Data that is identical for all regions")
 
     input_data_global = input_data.loc[input_data["source_region_code"] == ""]
 

--- a/app/tab_input_data.py
+++ b/app/tab_input_data.py
@@ -3,6 +3,7 @@
 import plotly.express as px
 import streamlit as st
 
+from app.plot_functions import plot_input_data_on_map
 from app.ptxboa_functions import display_and_edit_data_table, display_user_changes
 from ptxboa.api import PtxboaAPI
 
@@ -86,10 +87,24 @@ They also show the data for your country for comparison.
         missing_index_name = "parameter_code"
         missing_index_value = "interest rate"
 
-    c1, c2 = st.columns(2, gap="medium")
-    with c2:
-        # show data:
-        st.markdown("**Data:**")
+    c1, c2 = st.columns([2, 1], gap="large")
+    with c1:
+        st.markdown("**Map of input data values**")
+        if data_selection in ["full load hours", "CAPEX"]:
+            map_parameter = st.selectbox(
+                "Show Parameter on Map", process_code, key="input_data_map_parameter"
+            )
+        else:
+            map_parameter = "interest rate"
+        fig = plot_input_data_on_map(
+            api=api,
+            data_type=data_selection,
+            color_col=map_parameter,
+            scope="world",
+        )
+        st.plotly_chart(fig, use_container_width=True)
+
+    with st.expander(f"**Region specific {data_selection} data**"):
         df = display_and_edit_data_table(
             input_data=input_data_without_subregions,
             missing_index_name=missing_index_name,
@@ -100,10 +115,9 @@ They also show the data for your country for comparison.
             process_code=process_code,
             column_config=column_config,
         )
-
-    with c1:
+    with c2:
         # create plot:
-        st.markdown("**Figure:**")
+        st.markdown("**Value Distribution over Source regions:**")
         fig = px.box(df)
         st.plotly_chart(fig, use_container_width=True)
 

--- a/app/tab_input_data.py
+++ b/app/tab_input_data.py
@@ -87,8 +87,11 @@ They also show the data for your country for comparison.
         missing_index_name = "parameter_code"
         missing_index_value = "interest rate"
 
-    c1, c2 = st.columns([2, 1], gap="large")
-    with c1:
+    # in order to keep the figures horizontally aligned, we create two st.columns pairs
+    # the columns are identified by c_{row}_{column}, zero indexed
+    c_0_0, c_0_1 = st.columns([2, 1], gap="large")
+    c_1_0, c_1_1 = st.columns([2, 1], gap="large")
+    with c_0_0:
         st.markdown("**Map**")
         if data_selection in ["full load hours", "CAPEX"]:
             map_parameter = st.selectbox(
@@ -96,6 +99,7 @@ They also show the data for your country for comparison.
             )
         else:
             map_parameter = "interest rate"
+    with c_1_0:
         fig = plot_input_data_on_map(
             api=api,
             data_type=data_selection,
@@ -115,9 +119,10 @@ They also show the data for your country for comparison.
             process_code=process_code,
             column_config=column_config,
         )
-    with c2:
-        # create plot:
+    with c_0_1:
         st.markdown("**Regional Distribution**")
+    with c_1_1:
+        # create plot:
         fig = px.box(df)
         st.plotly_chart(fig, use_container_width=True)
 


### PR DESCRIPTION
Hi @markushal, quite some changes, please have a look and consider this as a first proposal. Open tasks to discuss:

- [x] should the boxplots and maps of the input data be next to or above of each other?
- [x] do we still need the `st.radio` in the deep dive countries tab when we show the costs on top and the full load hours below?
- [x] do you want to keep the hovers as they are now or should we highlight the selected parameter that is shown on the map in the hover for "CAPEX" and "full load hours"
- [ ] can we do some refactoring in order to use the same reshaping and selection routines before `app.ptxboa_functions.edit_and_display_data_table()` and `app.ptxboa_functions._choropleth_map_world()` / `app.ptxboa_functions._choropleth_map_deep_dive_country()`