### PR TITLE
Visibility of data editing mode

### DIFF
--- a/app/ptxboa_functions.py
+++ b/app/ptxboa_functions.py
@@ -187,19 +187,19 @@ def remove_subregions(api: PtxboaAPI, df: pd.DataFrame, country_name: str):
 
 def reset_user_changes():
     """Reset all user changes."""
-    if st.session_state["user_changes_df"] is not None:
+    if (
+        not st.session_state["edit_input_data"]
+        and st.session_state["user_changes_df"] is not None
+    ):
         st.session_state["user_changes_df"] = None
 
 
 def display_user_changes():
     """Display input data changes made by user."""
-    if st.session_state["user_changes_df"] is not None:
-        st.subheader("Data modifications:")
-        st.write("**Input data has been modified!**")
-        st.dataframe(
-            st.session_state["user_changes_df"].style.format(precision=3),
-            hide_index=True,
-        )
+    st.dataframe(
+        st.session_state["user_changes_df"].style.format(precision=3),
+        hide_index=True,
+    )
 
 
 def display_and_edit_data_table(

--- a/app/ptxboa_functions.py
+++ b/app/ptxboa_functions.py
@@ -196,10 +196,13 @@ def reset_user_changes():
 
 def display_user_changes():
     """Display input data changes made by user."""
-    st.dataframe(
-        st.session_state["user_changes_df"].style.format(precision=3),
-        hide_index=True,
-    )
+    if st.session_state["user_changes_df"] is not None:
+        st.dataframe(
+            st.session_state["user_changes_df"].style.format(precision=3),
+            hide_index=True,
+        )
+    else:
+        st.write("You have not changed any values yet.")
 
 
 def display_and_edit_data_table(

--- a/app/sidebar.py
+++ b/app/sidebar.py
@@ -2,6 +2,7 @@
 """Sidebar creation."""
 import streamlit as st
 
+from app.ptxboa_functions import reset_user_changes
 from ptxboa.api import PtxboaAPI
 
 
@@ -160,6 +161,7 @@ used in calculation and they will not be displayed in figures.
 Disable this setting to reset user data to default values.""",
         value=False,
         key="edit_input_data",
+        on_change=reset_user_changes,
     )
 
     return

--- a/app/tab_input_data.py
+++ b/app/tab_input_data.py
@@ -4,7 +4,7 @@ import plotly.express as px
 import streamlit as st
 
 from app.plot_functions import plot_input_data_on_map
-from app.ptxboa_functions import display_and_edit_data_table, display_user_changes
+from app.ptxboa_functions import display_and_edit_data_table
 from ptxboa.api import PtxboaAPI
 
 
@@ -172,6 +172,3 @@ They also show the data for your country for comparison.
         index="process_code",
         columns="parameter_code",
     )
-
-    # If there are user changes, display them:
-    display_user_changes()

--- a/ptxboa_streamlit.py
+++ b/ptxboa_streamlit.py
@@ -55,7 +55,6 @@ st.set_page_config(layout="wide")
 st.title("PtX Business Opportunity Analyzer :red[draft version, please do not quote!]")
 if st.session_state["edit_input_data"]:
     st.warning("Data editing on")
-if st.session_state["user_changes_df"] is not None:
     with st.expander("Modified data"):
         pf.display_user_changes()
 

--- a/ptxboa_streamlit.py
+++ b/ptxboa_streamlit.py
@@ -48,8 +48,18 @@ pd.set_option("display.float_format", "{:.2f}".format)
 if "user_changes_df" not in st.session_state:
     st.session_state["user_changes_df"] = None
 
+if "edit_input_data" not in st.session_state:
+    st.session_state["edit_input_data"] = False
+
 st.set_page_config(layout="wide")
 st.title("PtX Business Opportunity Analyzer :red[draft version, please do not quote!]")
+if st.session_state["edit_input_data"]:
+    st.warning("Data editing on")
+if st.session_state["user_changes_df"] is not None:
+    with st.expander("Modified data"):
+        pf.display_user_changes()
+
+
 (
     t_dashboard,
     t_market_scanning,
@@ -81,9 +91,6 @@ api = st.cache_resource(PtxboaAPI)()
 
 # create sidebar:
 make_sidebar(api)
-
-if st.session_state["edit_input_data"] is False:
-    pf.reset_user_changes()
 
 # import agora color scale:
 if "colors" not in st.session_state:


### PR DESCRIPTION
Hi Markus, 

this proposal would close #133, and close #134 I data editing mode is turned on, we show a warning above the tabs and the edited data table below the warning in an expander. What do you think about this design?

![grafik](https://github.com/agoenergy/ptx-boa/assets/38501948/6145235b-51f7-4a46-ab1b-6d98b365f056)

One issue with this approach: the app switches to the first tab (dashboard) when the data editing mode is changed.