### PR TITLE
move data editing info inside container

### DIFF
--- a/ptxboa_streamlit.py
+++ b/ptxboa_streamlit.py
@@ -52,10 +52,14 @@ if "edit_input_data" not in st.session_state:
 
 st.set_page_config(layout="wide")
 st.title("PtX Business Opportunity Analyzer :red[draft version, please do not quote!]")
-if st.session_state["edit_input_data"]:
-    st.warning("Data editing on")
-    with st.expander("Modified data"):
-        pf.display_user_changes()
+
+with st.container():
+    if st.session_state["edit_input_data"]:
+        st.warning("Data editing on")
+        with st.expander("Modified data"):
+            pf.display_user_changes()
+    else:
+        placeholder = st.empty()
 
 
 (


### PR DESCRIPTION
this resolves that the app jumps back to tab1 when the "edit_input_data" toggle is changed. See https://discuss.streamlit.io/t/returning-to-the-right-tab-after-clicking-button/31554/10