### PR TITLE
Restrict page width

### DIFF
--- a/app/layout_elements.py
+++ b/app/layout_elements.py
@@ -13,44 +13,43 @@ def display_costs(
     """Display costs as table and bar chart."""
     key_suffix = key_suffix.lower().replace(" ", "_")
     st.subheader(titlestring)
-    c1, c2 = st.columns([1, 5])
-    with c1:
-        # filter data:
-        df_res = df_costs.copy()
 
-        # select filter:
-        show_which_data = st.radio(
-            "Select elements to display:",
-            ["All", "Manual select"],
-            index=0,
-            key=f"show_which_data_{key}_{key_suffix}",
-        )
+    # filter data:
+    df_res = df_costs.copy()
 
-        # apply filter:
-        if show_which_data == "Manual select":
-            ind_select = st.multiselect(
-                "Select regions:",
-                df_res.index.values,
-                default=df_res.index.values,
-                key=f"select_data_{key}_{key_suffix}",
-            )
-            df_res = df_res.loc[ind_select]
+    # select filter:
+    show_which_data = st.radio(
+        "Select elements to display:",
+        ["All", "Manual select"],
+        index=0,
+        horizontal=True,
+        key=f"show_which_data_{key}_{key_suffix}",
+    )
 
-        # sort:
-        sort_ascending = st.toggle(
-            "Sort by total costs?",
-            value=True,
-            key=f"sort_data_{key}_{key_suffix}",
+    # apply filter:
+    if show_which_data == "Manual select":
+        ind_select = st.multiselect(
+            "Select regions:",
+            df_res.index.values,
+            default=df_res.index.values,
+            key=f"select_data_{key}_{key_suffix}",
         )
-        if sort_ascending:
-            df_res = df_res.sort_values(["Total"], ascending=True)
-    with c2:
-        # create graph:
-        fig = create_bar_chart_costs(
-            df_res,
-            current_selection=st.session_state[key],
-        )
-        st.plotly_chart(fig, use_container_width=True)
+        df_res = df_res.loc[ind_select]
+
+    # sort:
+    sort_ascending = st.toggle(
+        "Sort by total costs?",
+        value=True,
+        key=f"sort_data_{key}_{key_suffix}",
+    )
+    if sort_ascending:
+        df_res = df_res.sort_values(["Total"], ascending=True)
+    # create graph:
+    fig = create_bar_chart_costs(
+        df_res,
+        current_selection=st.session_state[key],
+    )
+    st.plotly_chart(fig, use_container_width=True)
 
     with st.expander("**Data**"):
         column_config = config_number_columns(

--- a/ptxboa_streamlit.py
+++ b/ptxboa_streamlit.py
@@ -50,7 +50,14 @@ if "user_changes_df" not in st.session_state:
 if "edit_input_data" not in st.session_state:
     st.session_state["edit_input_data"] = False
 
-st.set_page_config(layout="wide")
+# https://discuss.streamlit.io/t/can-not-set-page-width-in-streamlit-1-5-0/21522/5
+css = """
+<style>
+    section.main > div {max-width:80rem}
+</style>
+"""
+st.markdown(css, unsafe_allow_html=True)
+
 st.title("PtX Business Opportunity Analyzer :red[draft version, please do not quote!]")
 if st.session_state["edit_input_data"]:
     st.warning("Data editing on")


### PR DESCRIPTION
The wide layout which is currently used makes it difficult that the app looks okay both on large and smaller screens. This PR uses the centered layout but with increased width. See https://discuss.streamlit.io/t/can-not-set-page-width-in-streamlit-1-5-0/21522/5

I also put the data selection widgets above the cost barplots.