### PR TITLE
add `flow_code` column to `user_data` dataframe

### DIFF
--- a/app/ptxboa_functions.py
+++ b/app/ptxboa_functions.py
@@ -430,6 +430,7 @@ def display_user_changes(api):
                     "source_region_code": "Source Region",
                     "process_code": "Process",
                     "parameter_code": "Parameter",
+                    "flow_code": "Carrier/Material",
                     "value": "Value",
                 }
             ).style.format(precision=3),
@@ -467,7 +468,8 @@ def register_user_changes(
         res = pd.DataFrame(data_list)
 
         # add missing key (the info that is not contained in the 2D table):
-        res[missing_index_name] = missing_index_value
+        if missing_index_name is not None or missing_index_value is not None:
+            res[missing_index_name] = missing_index_value
 
         # Replace the 'id' values with the corresponding index elements from df_tab
         res[index] = res[index].map(lambda x: df_tab.index[x])
@@ -478,6 +480,7 @@ def register_user_changes(
                     "source_region_code",
                     "process_code",
                     "parameter_code",
+                    "flow_code",
                     "value",
                 ]
             )
@@ -486,7 +489,13 @@ def register_user_changes(
         st.session_state["user_changes_df"] = pd.concat(
             [st.session_state["user_changes_df"], res]
         ).drop_duplicates(
-            subset=["source_region_code", "process_code", "parameter_code"], keep="last"
+            subset=[
+                "source_region_code",
+                "process_code",
+                "parameter_code",
+                "flow_code",
+            ],
+            keep="last",
         )
 
 

--- a/app/user_data_from_file.py
+++ b/app/user_data_from_file.py
@@ -132,14 +132,14 @@ def _validate_correct_index_combinations(api, scenario, result):
         selector = (
             (input_data["parameter_code"] == row.parameter_code)
             & (input_data["process_code"] == row.process_code)
-            & (input_data["flow_code"] == "")
+            & (input_data["flow_code"] == row.flow_code)
             & (input_data["source_region_code"] == row.source_region_code)
             & (input_data["target_country_code"] == "")
         )
         if len(input_data.loc[selector]) == 0:
             result = (
                 f"invalid index combination '{row.source_region_code} "
-                f"| {row.process_code} | {row.parameter_code}'"
+                f"| {row.process_code} | {row.parameter_code} | {row.flow_code}'"
             )
             break
     return result
@@ -150,6 +150,7 @@ def _validate_correct_column_names(result):
         "source_region_code",
         "process_code",
         "parameter_code",
+        "flow_code",
         "value",
     }
     if set(result.columns) != required_cols:
@@ -181,6 +182,9 @@ def _validate_param_in_range(result):
         "lifetime / amortization period": (0, np.inf),
         "interest rate": (0, 1),
         "full load hours": (0, 8760),
+        "specific costs": (0, np.inf),
+        "losses (own fuel, transport)": (0, np.inf),
+        "levelized costs": (0, np.inf),
     }
     for row in result.itertuples():
         p = row.parameter_code

--- a/ptxboa/api.py
+++ b/ptxboa/api.py
@@ -97,7 +97,8 @@ class PtxboaAPI:
             user data that overrides scenario data
             contains only rows of scenario_data that have been modified.
             ids are expected to come as long names. Needs to have the columns
-            ["source_region_code", "process_code", "parameter_code", "value"].
+            "source_region_code", "process_code", "parameter_code", "flow_code", and
+            "value".
 
         Returns
         -------

--- a/ptxboa/api_data.py
+++ b/ptxboa/api_data.py
@@ -238,7 +238,8 @@ class PtxData:
             used in the frontend.
         user_data : pd.DataFrame | None, optional
             user data that overrides scenario data. DataFrame needs the columns
-            ["source_region_code", "process_code", "parameter_code",  "value"]
+            "source_region_code", "process_code", "parameter_code", "flow_code", and
+            "value".
         enforce_copy: bool
             Will always return a copy of the user data when true, when false, only
             returns a copy when user data is not None. When enforce_copy is False and
@@ -378,10 +379,9 @@ class PtxData:
         user_data = user_data.copy().fillna("")
         scenario_data = scenario_data.copy()
         # user data from frontend only has columns
-        # "source_region_code", "process_code", "value" and "parameter_code", we need
-        # replace missing columns "flow_code" and "target_country_code"
-        for missing_dim in ["flow_code", "target_country_code"]:
-            user_data[missing_dim] = ""
+        # "source_region_code", "process_code", "value" and "parameter_code", and
+        # "flow_code" we need to replace missing column "target_country_code"
+        user_data["target_country_code"] = ""
 
         # user data comes with long names from frontend
         user_data = self._map_names_and_codes(

--- a/tests/test_api_data.py
+++ b/tests/test_api_data.py
@@ -12,15 +12,21 @@ from ptxboa.api_data import DataHandler, PtxData
 def user_data_01():
     return pd.DataFrame(
         data=[
-            ("Australia", "PV tilted", 800, "CAPEX"),
-            ("Chile", "PV tilted", 900, "CAPEX"),
-            ("Chile", "Wind Offshore", 5000, "full load hours"),
-            ("Argentina", "PV tilted", 2000, "full load hours"),
-            ("Costa Rica", "Wind-PV-Hybrid", 2000, "full load hours"),
-            ("Australia", "Wind Onshore", 4000, "full load hours"),
-            ("Costa Rica", None, 0.12, "interest rate"),
+            ("Australia", "PV tilted", 800, "CAPEX", None),
+            ("Chile", "PV tilted", 900, "CAPEX", None),
+            ("Chile", "Wind Offshore", 5000, "full load hours", None),
+            ("Argentina", "PV tilted", 2000, "full load hours", None),
+            ("Costa Rica", "Wind-PV-Hybrid", 2000, "full load hours", None),
+            ("Australia", "Wind Onshore", 4000, "full load hours", None),
+            ("Costa Rica", None, 0.12, "interest rate", None),
         ],
-        columns=["source_region_code", "process_code", "value", "parameter_code"],
+        columns=[
+            "source_region_code",
+            "process_code",
+            "value",
+            "parameter_code",
+            "flow_code",
+        ],
     )
 
 

--- a/tests/test_user_data/non_existent_index_user_data.csv
+++ b/tests/test_user_data/non_existent_index_user_data.csv
@@ -1,22 +1,23 @@
-source_region_code,process_code,parameter_code,value
-Colombia,Wind-PV-Hybrid,CAPEX,3000.0
-Costa Rica,PV tilted,CAPEX,2000.0
-Spain,Wind Offshore,CAPEX,4000.0
-Indonesia,Wind Onshore,CAPEX,100.0
-Algeria,Wind Onshore,full load hours,4000.0
-Egypt,PV tilted,full load hours,8760.0
-India,Wind Offshore,full load hours,2000.0
-Kenya,Wind-PV-Hybrid,full load hours,5000.0
-India,Ammonia Synthesis (Haber-Bosch),efficiency,0.4
-,Direct Air Capture,CAPEX,1000.0
-,FT e-fuels Synthesis (Fischer-Tropsch),OPEX (fix),5000.0
-,FT e-fuels Synthesis (Fischer-Tropsch),lifetime / amortization period,100.0
-,Methane Synthesis,CAPEX,300.0
-,Methanol Synthesis,efficiency,1.0
-,PV tilted,lifetime / amortization period,50.0
-,Ammonia ship (own fuel consumption),levelized costs,100.0
-,Ammonia ship (own fuel consumption),"losses (own fuel, transport)",0.5
-,Autothermal-Reactor (Blue Hydrogen),lifetime / amortization period,40.0
-United Arab Emirates,,interest rate,0.0001
-Australia,,interest rate,0.9
-Colombia,,interest rate,1.0
+source_region_code,process_code,parameter_code,value,flow_code
+Colombia,Wind-PV-Hybrid,CAPEX,3000.0,
+Costa Rica,PV tilted,CAPEX,2000.0,
+Spain,Wind Offshore,CAPEX,4000.0,
+Indonesia,Wind Onshore,CAPEX,100.0,
+Algeria,Wind Onshore,full load hours,4000.0,
+Egypt,PV tilted,full load hours,8760.0,
+India,Wind Offshore,full load hours,2000.0,
+Kenya,Wind-PV-Hybrid,full load hours,5000.0,
+India,Ammonia Synthesis (Haber-Bosch),efficiency,0.4,
+,Direct Air Capture,CAPEX,1000.0,
+,FT e-fuels Synthesis (Fischer-Tropsch),OPEX (fix),5000.0,
+,FT e-fuels Synthesis (Fischer-Tropsch),lifetime / amortization period,100.0,
+,Methane Synthesis,CAPEX,300.0,
+,Methanol Synthesis,efficiency,1.0,
+,PV tilted,lifetime / amortization period,50.0,
+,Ammonia ship (own fuel consumption),levelized costs,100.0,
+,Ammonia ship (own fuel consumption),"losses (own fuel, transport)",0.5,
+,Autothermal-Reactor (Blue Hydrogen),lifetime / amortization period,40.0,
+United Arab Emirates,,interest rate,0.0001,
+Australia,,interest rate,0.9,
+Colombia,,interest rate,1.0,
+,,specific costs,0.3,heat

--- a/tests/test_user_data/non_numeric_empty_user_data.csv
+++ b/tests/test_user_data/non_numeric_empty_user_data.csv
@@ -1,22 +1,23 @@
-source_region_code,process_code,parameter_code,value
-Colombia,Wind-PV-Hybrid,CAPEX,3000.0
-Costa Rica,PV tilted,CAPEX,2000.0
-Spain,Wind Offshore,CAPEX,4000.0
-Indonesia,Wind Onshore,CAPEX,100.0
-Algeria,Wind Onshore,full load hours,4000.0
-Egypt,PV tilted,full load hours,8760.0
-India,Wind Offshore,full load hours,2000.0
-Kenya,Wind-PV-Hybrid,full load hours,
-,Ammonia Synthesis (Haber-Bosch),efficiency,0.4
-,Direct Air Capture,CAPEX,1000.0
-,FT e-fuels Synthesis (Fischer-Tropsch),OPEX (fix),5000.0
-,FT e-fuels Synthesis (Fischer-Tropsch),lifetime / amortization period,100.0
-,Methane Synthesis,CAPEX,300.0
-,Methanol Synthesis,efficiency,1.0
-,PV tilted,lifetime / amortization period,50.0
-,Ammonia ship (own fuel consumption),levelized costs,100.0
-,Ammonia ship (own fuel consumption),"losses (own fuel, transport)",0.5
-,Autothermal-Reactor (Blue Hydrogen),lifetime / amortization period,40.0
-United Arab Emirates,,interest rate,0.0001
-Australia,,interest rate,0.9
-Colombia,,interest rate,1.0
+source_region_code,process_code,parameter_code,value,flow_code
+Colombia,Wind-PV-Hybrid,CAPEX,3000.0,
+Costa Rica,PV tilted,CAPEX,2000.0,
+Spain,Wind Offshore,CAPEX,4000.0,
+Indonesia,Wind Onshore,CAPEX,100.0,
+Algeria,Wind Onshore,full load hours,4000.0,
+Egypt,PV tilted,full load hours,8760.0,
+India,Wind Offshore,full load hours,2000.0,
+Kenya,Wind-PV-Hybrid,full load hours,,
+,Ammonia Synthesis (Haber-Bosch),efficiency,0.4,
+,Direct Air Capture,CAPEX,1000.0,
+,FT e-fuels Synthesis (Fischer-Tropsch),OPEX (fix),5000.0,
+,FT e-fuels Synthesis (Fischer-Tropsch),lifetime / amortization period,100.0,
+,Methane Synthesis,CAPEX,300.0,
+,Methanol Synthesis,efficiency,1.0,
+,PV tilted,lifetime / amortization period,50.0,
+,Ammonia ship (own fuel consumption),levelized costs,100.0,
+,Ammonia ship (own fuel consumption),"losses (own fuel, transport)",0.5,
+,Autothermal-Reactor (Blue Hydrogen),lifetime / amortization period,40.0,
+United Arab Emirates,,interest rate,0.0001,
+Australia,,interest rate,0.9,
+Colombia,,interest rate,1.0,
+,,specific costs,0.3,heat

--- a/tests/test_user_data/non_numeric_nan_user_data.csv
+++ b/tests/test_user_data/non_numeric_nan_user_data.csv
@@ -1,22 +1,23 @@
-source_region_code,process_code,parameter_code,value
-Colombia,Wind-PV-Hybrid,CAPEX,3000.0
-Costa Rica,PV tilted,CAPEX,2000.0
-Spain,Wind Offshore,CAPEX,4000.0
-Indonesia,Wind Onshore,CAPEX,100.0
-Algeria,Wind Onshore,full load hours,NAN
-Egypt,PV tilted,full load hours,8760.0
-India,Wind Offshore,full load hours,2000.0
-Kenya,Wind-PV-Hybrid,full load hours,5000.0
-,Ammonia Synthesis (Haber-Bosch),efficiency,0.4
-,Direct Air Capture,CAPEX,1000.0
-,FT e-fuels Synthesis (Fischer-Tropsch),OPEX (fix),5000.0
-,FT e-fuels Synthesis (Fischer-Tropsch),lifetime / amortization period,100.0
-,Methane Synthesis,CAPEX,300.0
-,Methanol Synthesis,efficiency,1.0
-,PV tilted,lifetime / amortization period,50.0
-,Ammonia ship (own fuel consumption),levelized costs,100.0
-,Ammonia ship (own fuel consumption),"losses (own fuel, transport)",0.5
-,Autothermal-Reactor (Blue Hydrogen),lifetime / amortization period,40.0
-United Arab Emirates,,interest rate,0.0001
-Australia,,interest rate,0.9
-Colombia,,interest rate,1.0
+source_region_code,process_code,parameter_code,value,flow_code
+Colombia,Wind-PV-Hybrid,CAPEX,3000.0,
+Costa Rica,PV tilted,CAPEX,2000.0,
+Spain,Wind Offshore,CAPEX,4000.0,
+Indonesia,Wind Onshore,CAPEX,100.0,
+Algeria,Wind Onshore,full load hours,NAN,
+Egypt,PV tilted,full load hours,8760.0,
+India,Wind Offshore,full load hours,2000.0,
+Kenya,Wind-PV-Hybrid,full load hours,5000.0,
+,Ammonia Synthesis (Haber-Bosch),efficiency,0.4,
+,Direct Air Capture,CAPEX,1000.0,
+,FT e-fuels Synthesis (Fischer-Tropsch),OPEX (fix),5000.0,
+,FT e-fuels Synthesis (Fischer-Tropsch),lifetime / amortization period,100.0,
+,Methane Synthesis,CAPEX,300.0,
+,Methanol Synthesis,efficiency,1.0,
+,PV tilted,lifetime / amortization period,50.0,
+,Ammonia ship (own fuel consumption),levelized costs,100.0,
+,Ammonia ship (own fuel consumption),"losses (own fuel, transport)",0.5,
+,Autothermal-Reactor (Blue Hydrogen),lifetime / amortization period,40.0,
+United Arab Emirates,,interest rate,0.0001,
+Australia,,interest rate,0.9,
+Colombia,,interest rate,1.0,
+,,specific costs,0.3,heat

--- a/tests/test_user_data/non_numeric_string_user_data.csv
+++ b/tests/test_user_data/non_numeric_string_user_data.csv
@@ -1,22 +1,23 @@
-source_region_code,process_code,parameter_code,value
-Colombia,Wind-PV-Hybrid,CAPEX,3000.0
-Costa Rica,PV tilted,CAPEX,2000.0
-Spain,Wind Offshore,CAPEX,4000.0
-Indonesia,Wind Onshore,CAPEX,100.0
-Algeria,Wind Onshore,full load hours,4000.0
-Egypt,PV tilted,full load hours,8760.0
-India,Wind Offshore,full load hours,2000.0
-Kenya,Wind-PV-Hybrid,full load hours,5000.0
-,Ammonia Synthesis (Haber-Bosch),efficiency,0.4
-,Direct Air Capture,CAPEX,1000.0
-,FT e-fuels Synthesis (Fischer-Tropsch),OPEX (fix),5000.0
-,FT e-fuels Synthesis (Fischer-Tropsch),lifetime / amortization period,100.0
-,Methane Synthesis,CAPEX,300.0
-,Methanol Synthesis,efficiency,1.0
-,PV tilted,lifetime / amortization period,50.0
-,Ammonia ship (own fuel consumption),levelized costs,100.0
-,Ammonia ship (own fuel consumption),"losses (own fuel, transport)",string_entry
-,Autothermal-Reactor (Blue Hydrogen),lifetime / amortization period,40.0
-United Arab Emirates,,interest rate,0.0001
-Australia,,interest rate,0.9
-Colombia,,interest rate,1.0
+source_region_code,process_code,parameter_code,value,flow_code
+Colombia,Wind-PV-Hybrid,CAPEX,3000.0,
+Costa Rica,PV tilted,CAPEX,2000.0,
+Spain,Wind Offshore,CAPEX,4000.0,
+Indonesia,Wind Onshore,CAPEX,100.0,
+Algeria,Wind Onshore,full load hours,4000.0,
+Egypt,PV tilted,full load hours,8760.0,
+India,Wind Offshore,full load hours,2000.0,
+Kenya,Wind-PV-Hybrid,full load hours,5000.0,
+,Ammonia Synthesis (Haber-Bosch),efficiency,0.4,
+,Direct Air Capture,CAPEX,1000.0,
+,FT e-fuels Synthesis (Fischer-Tropsch),OPEX (fix),5000.0,
+,FT e-fuels Synthesis (Fischer-Tropsch),lifetime / amortization period,100.0,
+,Methane Synthesis,CAPEX,300.0,
+,Methanol Synthesis,efficiency,1.0,
+,PV tilted,lifetime / amortization period,50.0,
+,Ammonia ship (own fuel consumption),levelized costs,100.0,
+,Ammonia ship (own fuel consumption),"losses (own fuel, transport)",string_entry,
+,Autothermal-Reactor (Blue Hydrogen),lifetime / amortization period,40.0,
+United Arab Emirates,,interest rate,0.0001,
+Australia,,interest rate,0.9,
+Colombia,,interest rate,1.0,
+,,specific costs,0.3,heat

--- a/tests/test_user_data/param_above_range_user_data.csv
+++ b/tests/test_user_data/param_above_range_user_data.csv
@@ -1,22 +1,23 @@
-source_region_code,process_code,parameter_code,value
-Colombia,Wind-PV-Hybrid,CAPEX,3000.0
-Costa Rica,PV tilted,CAPEX,2000.0
-Spain,Wind Offshore,CAPEX,4000.0
-Indonesia,Wind Onshore,CAPEX,100.0
-Algeria,Wind Onshore,full load hours,4000.0
-Egypt,PV tilted,full load hours,8760.0
-India,Wind Offshore,full load hours,10000.0
-Kenya,Wind-PV-Hybrid,full load hours,5000.0
-,Ammonia Synthesis (Haber-Bosch),efficiency,0.4
-,Direct Air Capture,CAPEX,1000.0
-,FT e-fuels Synthesis (Fischer-Tropsch),OPEX (fix),5000.0
-,FT e-fuels Synthesis (Fischer-Tropsch),lifetime / amortization period,100.0
-,Methane Synthesis,CAPEX,300.0
-,Methanol Synthesis,efficiency,1.0
-,PV tilted,lifetime / amortization period,50.0
-,Ammonia ship (own fuel consumption),levelized costs,100.0
-,Ammonia ship (own fuel consumption),"losses (own fuel, transport)",0.5
-,Autothermal-Reactor (Blue Hydrogen),lifetime / amortization period,40.0
-United Arab Emirates,,interest rate,0.0001
-Australia,,interest rate,0.9
-Colombia,,interest rate,1.0
+source_region_code,process_code,parameter_code,value,flow_code
+Colombia,Wind-PV-Hybrid,CAPEX,3000.0,
+Costa Rica,PV tilted,CAPEX,2000.0,
+Spain,Wind Offshore,CAPEX,4000.0,
+Indonesia,Wind Onshore,CAPEX,100.0,
+Algeria,Wind Onshore,full load hours,4000.0,
+Egypt,PV tilted,full load hours,8760.0,
+India,Wind Offshore,full load hours,10000.0,
+Kenya,Wind-PV-Hybrid,full load hours,5000.0,
+,Ammonia Synthesis (Haber-Bosch),efficiency,0.4,
+,Direct Air Capture,CAPEX,1000.0,
+,FT e-fuels Synthesis (Fischer-Tropsch),OPEX (fix),5000.0,
+,FT e-fuels Synthesis (Fischer-Tropsch),lifetime / amortization period,100.0,
+,Methane Synthesis,CAPEX,300.0,
+,Methanol Synthesis,efficiency,1.0,
+,PV tilted,lifetime / amortization period,50.0,
+,Ammonia ship (own fuel consumption),levelized costs,100.0,
+,Ammonia ship (own fuel consumption),"losses (own fuel, transport)",0.5,
+,Autothermal-Reactor (Blue Hydrogen),lifetime / amortization period,40.0,
+United Arab Emirates,,interest rate,0.0001,
+Australia,,interest rate,0.9,
+Colombia,,interest rate,1.0,
+,,specific costs,0.3,heat

--- a/tests/test_user_data/param_below_range_user_data.csv
+++ b/tests/test_user_data/param_below_range_user_data.csv
@@ -1,22 +1,23 @@
-source_region_code,process_code,parameter_code,value
-Colombia,Wind-PV-Hybrid,CAPEX,3000.0
-Costa Rica,PV tilted,CAPEX,2000.0
-Spain,Wind Offshore,CAPEX,4000.0
-Indonesia,Wind Onshore,CAPEX,100.0
-Algeria,Wind Onshore,full load hours,4000.0
-Egypt,PV tilted,full load hours,8760.0
-India,Wind Offshore,full load hours,2000.0
-Kenya,Wind-PV-Hybrid,full load hours,5000.0
-,Ammonia Synthesis (Haber-Bosch),efficiency,0.4
-,Direct Air Capture,CAPEX,1000.0
-,FT e-fuels Synthesis (Fischer-Tropsch),OPEX (fix),-100.0
-,FT e-fuels Synthesis (Fischer-Tropsch),lifetime / amortization period,100.0
-,Methane Synthesis,CAPEX,300.0
-,Methanol Synthesis,efficiency,1.0
-,PV tilted,lifetime / amortization period,50.0
-,Ammonia ship (own fuel consumption),levelized costs,100.0
-,Ammonia ship (own fuel consumption),"losses (own fuel, transport)",0.5
-,Autothermal-Reactor (Blue Hydrogen),lifetime / amortization period,40.0
-United Arab Emirates,,interest rate,0.0001
-Australia,,interest rate,0.9
-Colombia,,interest rate,1.0
+source_region_code,process_code,parameter_code,value,flow_code
+Colombia,Wind-PV-Hybrid,CAPEX,3000.0,
+Costa Rica,PV tilted,CAPEX,2000.0,
+Spain,Wind Offshore,CAPEX,4000.0,
+Indonesia,Wind Onshore,CAPEX,100.0,
+Algeria,Wind Onshore,full load hours,4000.0,
+Egypt,PV tilted,full load hours,8760.0,
+India,Wind Offshore,full load hours,2000.0,
+Kenya,Wind-PV-Hybrid,full load hours,5000.0,
+,Ammonia Synthesis (Haber-Bosch),efficiency,0.4,
+,Direct Air Capture,CAPEX,1000.0,
+,FT e-fuels Synthesis (Fischer-Tropsch),OPEX (fix),-100.0,
+,FT e-fuels Synthesis (Fischer-Tropsch),lifetime / amortization period,100.0,
+,Methane Synthesis,CAPEX,300.0,
+,Methanol Synthesis,efficiency,1.0,
+,PV tilted,lifetime / amortization period,50.0,
+,Ammonia ship (own fuel consumption),levelized costs,100.0,
+,Ammonia ship (own fuel consumption),"losses (own fuel, transport)",0.5,
+,Autothermal-Reactor (Blue Hydrogen),lifetime / amortization period,40.0,
+United Arab Emirates,,interest rate,0.0001,
+Australia,,interest rate,0.9,
+Colombia,,interest rate,1.0,
+,,specific costs,0.3,heat

--- a/tests/test_user_data/too_many_columns_user_data.csv
+++ b/tests/test_user_data/too_many_columns_user_data.csv
@@ -1,22 +1,23 @@
-source_region_code,process_code,parameter_code,value,additional_column
-Colombia,Wind-PV-Hybrid,CAPEX,3000.0,None
-Costa Rica,PV tilted,CAPEX,2000.0,None
-Spain,Wind Offshore,CAPEX,4000.0,None
-Indonesia,Wind Onshore,CAPEX,100.0,None
-Algeria,Wind Onshore,full load hours,4000.0,None
-Egypt,PV tilted,full load hours,8760.0,None
-India,Wind Offshore,full load hours,2000.0,None
-Kenya,Wind-PV-Hybrid,full load hours,5000.0,None
-,Ammonia Synthesis (Haber-Bosch),efficiency,0.4,None
-,Direct Air Capture,CAPEX,1000.0,None
-,FT e-fuels Synthesis (Fischer-Tropsch),OPEX (fix),5000.0,None
-,FT e-fuels Synthesis (Fischer-Tropsch),lifetime / amortization period,100.0,None
-,Methane Synthesis,CAPEX,300.0,None
-,Methanol Synthesis,efficiency,1.0,None
-,PV tilted,lifetime / amortization period,50.0,None
-,Ammonia ship (own fuel consumption),levelized costs,100.0,None
-,Ammonia ship (own fuel consumption),"losses (own fuel, transport)",0.5,None
-,Autothermal-Reactor (Blue Hydrogen),lifetime / amortization period,40.0,None
-United Arab Emirates,,interest rate,0.0001,None
-Australia,,interest rate,0.9,None
-Colombia,,interest rate,1.0,None
+source_region_code,process_code,parameter_code,value,flow_code,additional_column
+Colombia,Wind-PV-Hybrid,CAPEX,3000.0,,None
+Costa Rica,PV tilted,CAPEX,2000.0,,None
+Spain,Wind Offshore,CAPEX,4000.0,,None
+Indonesia,Wind Onshore,CAPEX,100.0,,None
+Algeria,Wind Onshore,full load hours,4000.0,,None
+Egypt,PV tilted,full load hours,8760.0,,None
+India,Wind Offshore,full load hours,2000.0,,None
+Kenya,Wind-PV-Hybrid,full load hours,5000.0,,None
+,Ammonia Synthesis (Haber-Bosch),efficiency,0.4,,None
+,Direct Air Capture,CAPEX,1000.0,,None
+,FT e-fuels Synthesis (Fischer-Tropsch),OPEX (fix),5000.0,,None
+,FT e-fuels Synthesis (Fischer-Tropsch),lifetime / amortization period,100.0,,None
+,Methane Synthesis,CAPEX,300.0,,None
+,Methanol Synthesis,efficiency,1.0,,None
+,PV tilted,lifetime / amortization period,50.0,,None
+,Ammonia ship (own fuel consumption),levelized costs,100.0,,None
+,Ammonia ship (own fuel consumption),"losses (own fuel, transport)",0.5,,None
+,Autothermal-Reactor (Blue Hydrogen),lifetime / amortization period,40.0,,None
+United Arab Emirates,,interest rate,0.0001,,None
+Australia,,interest rate,0.9,,None
+Colombia,,interest rate,1.0,,None
+,,specific costs,0.3,heat

--- a/tests/test_user_data/valid_user_data.csv
+++ b/tests/test_user_data/valid_user_data.csv
@@ -1,22 +1,23 @@
-source_region_code,process_code,parameter_code,value
-Colombia,Wind-PV-Hybrid,CAPEX,3000.0
-Costa Rica,PV tilted,CAPEX,2000.0
-Spain,Wind Offshore,CAPEX,4000.0
-Indonesia,Wind Onshore,CAPEX,100.0
-Algeria,Wind Onshore,full load hours,4000.0
-Egypt,PV tilted,full load hours,8760.0
-India,Wind Offshore,full load hours,2000.0
-Kenya,Wind-PV-Hybrid,full load hours,5000.0
-,Ammonia Synthesis (Haber-Bosch),efficiency,0.4
-,Direct Air Capture,CAPEX,1000.0
-,FT e-fuels Synthesis (Fischer-Tropsch),OPEX (fix),5000.0
-,FT e-fuels Synthesis (Fischer-Tropsch),lifetime / amortization period,100.0
-,Methane Synthesis,CAPEX,300.0
-,Methanol Synthesis,efficiency,1.0
-,PV tilted,lifetime / amortization period,50.0
-,Ammonia ship (own fuel consumption),levelized costs,100.0
-,Ammonia ship (own fuel consumption),"losses (own fuel, transport)",0.5
-,Autothermal-Reactor (Blue Hydrogen),lifetime / amortization period,40.0
-United Arab Emirates,,interest rate,0.0001
-Australia,,interest rate,0.9
-Colombia,,interest rate,1.0
+source_region_code,process_code,parameter_code,value,flow_code
+Colombia,Wind-PV-Hybrid,CAPEX,3000.0,
+Costa Rica,PV tilted,CAPEX,2000.0,
+Spain,Wind Offshore,CAPEX,4000.0,
+Indonesia,Wind Onshore,CAPEX,100.0,
+Algeria,Wind Onshore,full load hours,4000.0,
+Egypt,PV tilted,full load hours,8760.0,
+India,Wind Offshore,full load hours,2000.0,
+Kenya,Wind-PV-Hybrid,full load hours,5000.0,
+,Ammonia Synthesis (Haber-Bosch),efficiency,0.4,
+,Direct Air Capture,CAPEX,1000.0,
+,FT e-fuels Synthesis (Fischer-Tropsch),OPEX (fix),5000.0,
+,FT e-fuels Synthesis (Fischer-Tropsch),lifetime / amortization period,100.0,
+,Methane Synthesis,CAPEX,300.0,
+,Methanol Synthesis,efficiency,1.0,
+,PV tilted,lifetime / amortization period,50.0,
+,Ammonia ship (own fuel consumption),levelized costs,100.0,
+,Ammonia ship (own fuel consumption),"losses (own fuel, transport)",0.5,
+,Autothermal-Reactor (Blue Hydrogen),lifetime / amortization period,40.0,
+United Arab Emirates,,interest rate,0.0001,
+Australia,,interest rate,0.9,
+Colombia,,interest rate,1.0,
+,,specific costs,0.3,heat

--- a/tests/test_user_data/wrong_column_name_user_data.csv
+++ b/tests/test_user_data/wrong_column_name_user_data.csv
@@ -1,22 +1,23 @@
-source_region_code,process_code,bad_column_name,value
-Colombia,Wind-PV-Hybrid,CAPEX,3000.0
-Costa Rica,PV tilted,CAPEX,2000.0
-Spain,Wind Offshore,CAPEX,4000.0
-Indonesia,Wind Onshore,CAPEX,100.0
-Algeria,Wind Onshore,full load hours,4000.0
-Egypt,PV tilted,full load hours,8760.0
-India,Wind Offshore,full load hours,2000.0
-Kenya,Wind-PV-Hybrid,full load hours,5000.0
-,Ammonia Synthesis (Haber-Bosch),efficiency,0.4
-,Direct Air Capture,CAPEX,1000.0
-,FT e-fuels Synthesis (Fischer-Tropsch),OPEX (fix),5000.0
-,FT e-fuels Synthesis (Fischer-Tropsch),lifetime / amortization period,100.0
-,Methane Synthesis,CAPEX,300.0
-,Methanol Synthesis,efficiency,1.0
-,PV tilted,lifetime / amortization period,50.0
-,Ammonia ship (own fuel consumption),levelized costs,100.0
-,Ammonia ship (own fuel consumption),"losses (own fuel, transport)",0.5
-,Autothermal-Reactor (Blue Hydrogen),lifetime / amortization period,40.0
-United Arab Emirates,,interest rate,0.0001
-Australia,,interest rate,0.9
-Colombia,,interest rate,1.0
+source_region_code,process_code,bad_column_name,value,flow_code
+Colombia,Wind-PV-Hybrid,CAPEX,3000.0,
+Costa Rica,PV tilted,CAPEX,2000.0,
+Spain,Wind Offshore,CAPEX,4000.0,
+Indonesia,Wind Onshore,CAPEX,100.0,
+Algeria,Wind Onshore,full load hours,4000.0,
+Egypt,PV tilted,full load hours,8760.0,
+India,Wind Offshore,full load hours,2000.0,
+Kenya,Wind-PV-Hybrid,full load hours,5000.0,
+,Ammonia Synthesis (Haber-Bosch),efficiency,0.4,
+,Direct Air Capture,CAPEX,1000.0,
+,FT e-fuels Synthesis (Fischer-Tropsch),OPEX (fix),5000.0,
+,FT e-fuels Synthesis (Fischer-Tropsch),lifetime / amortization period,100.0,
+,Methane Synthesis,CAPEX,300.0,
+,Methanol Synthesis,efficiency,1.0,
+,PV tilted,lifetime / amortization period,50.0,
+,Ammonia ship (own fuel consumption),levelized costs,100.0,
+,Ammonia ship (own fuel consumption),"losses (own fuel, transport)",0.5,
+,Autothermal-Reactor (Blue Hydrogen),lifetime / amortization period,40.0,
+United Arab Emirates,,interest rate,0.0001,
+Australia,,interest rate,0.9,
+Colombia,,interest rate,1.0,
+,,specific costs,0.3,heat

--- a/tests/test_user_data_from_file.py
+++ b/tests/test_user_data_from_file.py
@@ -63,15 +63,15 @@ def param_above_range_user_data() -> pd.DataFrame:
         ("valid_user_data", "valid_user_data"),
         (
             "wrong_column_name_user_data",
-            "column names must be ['parameter_code', 'process_code', 'source_region_code', 'value']",  # noqa
+            "column names must be ['flow_code', 'parameter_code', 'process_code', 'source_region_code', 'value']",  # noqa
         ),
         (
             "too_many_columns_user_data",
-            "column names must be ['parameter_code', 'process_code', 'source_region_code', 'value']",  # noqa
+            "column names must be ['flow_code', 'parameter_code', 'process_code', 'source_region_code', 'value']",  # noqa
         ),
         (
             "non_existent_index_user_data",
-            "invalid index combination 'India | Ammonia Synthesis (Haber-Bosch) | efficiency'",  # noqa
+            "invalid index combination 'India | Ammonia Synthesis (Haber-Bosch) | efficiency | '",  # noqa
         ),
         (
             "non_numeric_empty_user_data",


### PR DESCRIPTION
Hi Markus @markushal,
this fixes your issue with the missing flow code (https://github.com/agoenergy/ptx-boa/pull/184#issuecomment-1852399442). 

`target_country_code` is still missing and thus not editable by the user, is this intentional?