### PR TITLE
include selected subregion in global cost comparison

### DIFF
--- a/app/ptxboa_functions.py
+++ b/app/ptxboa_functions.py
@@ -439,7 +439,9 @@ def get_data_type_from_input_data(
     return df
 
 
-def remove_subregions(api: PtxboaAPI, df: pd.DataFrame, country_name: str):
+def remove_subregions(
+    api: PtxboaAPI, df: pd.DataFrame, country_name: str, keep: str | None = None
+):
     """Remove subregions from a dataframe.
 
     Parameters
@@ -452,6 +454,9 @@ def remove_subregions(api: PtxboaAPI, df: pd.DataFrame, country_name: str):
 
     country_name : str
         name of target country. Is removed from region list if it is also in there.
+
+    keep : str or None, by default None
+        can be used to keep data for a specific subregion
 
     Returns
     -------
@@ -472,6 +477,9 @@ def remove_subregions(api: PtxboaAPI, df: pd.DataFrame, country_name: str):
     region_list_without_subregions = [
         r for r in region_list_without_subregions if r in df.index
     ]
+
+    if keep is not None:
+        region_list_without_subregions.append(keep)
 
     df = df.loc[region_list_without_subregions]
 

--- a/app/sidebar.py
+++ b/app/sidebar.py
@@ -49,6 +49,7 @@ def main_settings(api):
         index=region_list.get_loc("Morocco"),  # Morocco as default
     )
     st.session_state["region"] = region
+    st.session_state["subregion"] = None
 
     # If a deep dive country has been selected, add option to select subregion:
     if region in ["Argentina", "Morocco", "South Africa"]:
@@ -64,6 +65,7 @@ def main_settings(api):
         )
         if subregion is not None:
             st.session_state["region"] = subregion
+            st.session_state["subregion"] = subregion
 
     # select demand country:
     countries = api.get_dimension("country").index

--- a/app/tab_costs.py
+++ b/app/tab_costs.py
@@ -79,12 +79,18 @@ def content_costs(
 
     with st.container(border=True):
         display_costs(
-            remove_subregions(api, costs_per_region, st.session_state["country"]),
+            remove_subregions(
+                api,
+                costs_per_region,
+                st.session_state["country"],
+                keep=st.session_state["subregion"],
+            ),
             (
                 remove_subregions(
                     api,
                     costs_per_region_without_user_changes,
                     st.session_state["country"],
+                    keep=st.session_state["subregion"],
                 )
                 if st.session_state["user_changes_df"] is not None
                 else None


### PR DESCRIPTION
Fixes #410

subregion inclusion is only realized in the bar plot comparison and not yet in the global map. 