### PR TITLE
move storage parameters to dedicated table

### DIFF
--- a/app/layout_elements.py
+++ b/app/layout_elements.py
@@ -267,6 +267,7 @@ def display_and_edit_input_data(
         "specific_costs",
         "conversion_coefficients",
         "dac_and_desalination",
+        "storage",
     ],
     scope: Literal["world", "Argentina", "Morocco", "South Africa"],
     key: str,
@@ -320,6 +321,7 @@ def display_and_edit_input_data(
         "transportation_processes",
         "reconversion_processes",
         "dac_and_desalination",
+        "storage",
     ]:
         index = "process_code"
         columns = "parameter_code"
@@ -415,6 +417,11 @@ def display_and_edit_input_data(
         missing_index_name = "parameter_code"
         missing_index_value = "conversion factors"
         column_config = get_column_config()
+
+    if data_type == "storage":
+        column_config["OPEX (fix)"] = st.column_config.NumberColumn(
+            format="%.2f USD/kW", min_value=0
+        )
 
     df = change_index_names(df)
 

--- a/app/ptxboa_functions.py
+++ b/app/ptxboa_functions.py
@@ -271,6 +271,7 @@ def get_data_type_from_input_data(
         "specific_costs",
         "conversion_coefficients",
         "dac_and_desalination",
+        "storage",
     ],
     scope: Literal[None, "world", "Argentina", "Morocco", "South Africa"],
 ) -> pd.DataFrame:
@@ -329,6 +330,7 @@ def get_data_type_from_input_data(
         "transportation_processes",
         "reconversion_processes",
         "dac_and_desalination",
+        "storage",
     ]:
         scope = None
         source_region_code = [""]
@@ -398,6 +400,8 @@ def get_data_type_from_input_data(
         process_code = processes.loc[
             processes["is_transport"] & ~processes["is_transformation"], "process_name"
         ].to_list()
+        # remove storage processes
+        process_code = [c for c in process_code if "storage" not in c]
 
     if data_type == "reconversion_processes":
         parameter_code = [
@@ -426,6 +430,17 @@ def get_data_type_from_input_data(
             "Wind Offshore",
             "PV tilted",
         ]
+
+    if data_type == "storage":
+        parameter_code = [
+            "CAPEX",
+            "OPEX (fix)",
+            "lifetime / amortization period",
+            "efficiency",
+        ]
+        process_code = processes.loc[
+            processes["process_name"].str.contains("storage"), "process_name"
+        ].to_list()
 
     df = subset_and_pivot_input_data(
         input_data,

--- a/app/tab_input_data.py
+++ b/app/tab_input_data.py
@@ -115,6 +115,15 @@ def content_input_data(api: PtxboaAPI) -> None:
                 scope=None,
                 key="input_data_conversion_processes",
             )
+        with st.expander("**Storage**"):
+            st.caption("Assumptions for storage")
+            display_and_edit_input_data(
+                api,
+                data_type="storage",
+                scope=None,
+                key="input_data_storage",
+            )
+
         with st.expander("**Transportation (ships and pipelines)**"):
             st.caption(
                 (

--- a/app/tab_input_data.py
+++ b/app/tab_input_data.py
@@ -116,7 +116,19 @@ def content_input_data(api: PtxboaAPI) -> None:
                 key="input_data_conversion_processes",
             )
         with st.expander("**Storage**"):
-            st.caption("Assumptions for storage")
+            st.caption(
+                (
+                    "- Storage CAPEX are defined per charging power.\n"
+                    "- Efficiencies are round-trip.\n"
+                    "- Time-dependent losses are neglected.\n"
+                    "- For electricity storage (batteries) we assume a fixed ratio of 4"
+                    " MWh storage capacity per MW charging power\n"
+                    " and equal charging/discharging power.\n"
+                    "- For hydrogen storage (tanks) we assume storage capacity and"
+                    " discharge power to be non-binding because the comporessor is by"
+                    " far the most expensive component."
+                )
+            )
             display_and_edit_input_data(
                 api,
                 data_type="storage",


### PR DESCRIPTION
Fixes #447

I would prefer if parameters that are hard coded in optimize function (storage capacity) are not part of the table. Is it possible to put them to the st.caption of the storage expander?