### PR TITLE
compare blue costs with green costs

### DIFF
--- a/app/ptxboa_functions.py
+++ b/app/ptxboa_functions.py
@@ -203,7 +203,7 @@ def calculate_results_list_green(
 
 def calculate_results_list_blue(
     api: PtxboaAPI,
-    parameter_to_change: Literal["region", "chain", "carbon_dioxide_price"],
+    parameter_to_change: Literal["region", "chain", "carbon_dioxide_price", "scenario"],
     parameter_list: None | list | pd.Series | pd.Index = None,
     override_session_state: dict | None = None,
     apply_user_data: bool = True,
@@ -220,6 +220,7 @@ def calculate_results_list_blue(
         "country",
         "output_unit",
         "region",
+        "scenario",
         "secproc_co2",
         "secproc_water",
         "ship_own_fuel",
@@ -245,11 +246,10 @@ def calculate_results_list_blue(
         settings.update(override_session_state)
 
     # hardcoded values which are not relevant for blue version
-    settings["scenario"] = "2040 (medium)"
     settings["res_gen"] = "Wind-PV-Hybrid"
 
     if parameter_list is None:
-        if parameter_to_change in ["region", "chain"]:
+        if parameter_to_change in ["region", "chain", "scenario"]:
             parameter_list = api.get_dimension(parameter_to_change).index
         elif parameter_to_change in ["carbon_dioxide_price"]:
             parameter_list = [0.9, 0.95, 1.0, 1.05, 1.1]
@@ -261,7 +261,7 @@ def calculate_results_list_blue(
         parameter_list = parameter_list[~parameter_list.str.startswith("Green Iron")]
 
     res_list = []
-    if parameter_to_change in ["region", "chain"]:
+    if parameter_to_change in ["region", "chain", "scenario"]:
         for change_factor in parameter_list:
             settings.update({parameter_to_change: change_factor})
             if parameter_to_change == "chain":
@@ -979,7 +979,7 @@ def green_costs_over_dimension(
 
 def blue_results_over_dimension(
     api,
-    dim: Literal["region", "chain", "carbon_dioxide_price"],
+    dim: Literal["region", "chain", "carbon_dioxide_price", "scenario"],
     parameter_list: None | list | pd.Series = None,
     override_session_state=None,
 ):

--- a/app/ptxboa_functions.py
+++ b/app/ptxboa_functions.py
@@ -9,13 +9,33 @@ import pandas as pd
 import streamlit as st
 
 from ptxboa.api import PtxboaAPI
+from ptxboa.static import (
+    ChainNameType,
+    OutputUnitType,
+    ResGenType,
+    ScenarioType,
+    SecProcCO2Type,
+    SecProcH2OType,
+    SourceRegionNameType,
+    TargetCountryNameType,
+    TransportType,
+)
 from ptxboa.utils import is_test
 
 
 @st.cache_data(show_spinner=False)
-def calculate_results_single(
+def calculate_costs_cached(
     _api: PtxboaAPI,
-    settings: dict,
+    scenario: ScenarioType,
+    secproc_co2: SecProcCO2Type,
+    secproc_water: SecProcH2OType,
+    chain: ChainNameType,
+    res_gen: ResGenType,
+    region: SourceRegionNameType,
+    country: TargetCountryNameType,
+    transport: TransportType,
+    ship_own_fuel: bool,
+    output_unit: OutputUnitType,
     user_data: pd.DataFrame | None = None,
     optimize_flh: bool = True,
     use_user_data_for_optimize_flh: bool = False,
@@ -36,8 +56,17 @@ def calculate_results_single(
         same format as for :meth:`~ptxboa.api.PtxboaAPI.calculate()`
     """
     res = _api.calculate(
+        scenario=scenario,
+        secproc_co2=secproc_co2,
+        secproc_water=secproc_water,
+        chain=chain,
+        res_gen=res_gen,
+        region=region,
+        country=country,
+        transport=transport,
+        ship_own_fuel=ship_own_fuel,
+        output_unit=output_unit,
         user_data=user_data,
-        **settings,
         optimize_flh=optimize_flh,
         use_user_data_for_optimize_flh=use_user_data_for_optimize_flh,
     ).costs
@@ -154,14 +183,14 @@ def calculate_results_list_green(
 
         # catch all api errors so that the tool is stable
         try:
-            res_single = calculate_results_single(
+            res_single = calculate_costs_cached(
                 api,
-                settings,
                 user_data=(
                     st.session_state["user_changes_df"] if apply_user_data else None
                 ),
                 optimize_flh=optimize_flh,
                 use_user_data_for_optimize_flh=use_user_data_for_optimize_flh,
+                **settings,
             )
             res_list.append(res_single)
         except Exception as exc:
@@ -249,14 +278,14 @@ def calculate_results_list_blue(
                     settings.update({"secproc_co2": None})
 
             try:
-                res_single = calculate_results_single(
+                res_single = calculate_costs_cached(
                     api,
-                    settings,
                     user_data=(
                         st.session_state["user_changes_df"] if apply_user_data else None
                     ),
                     optimize_flh=False,
                     use_user_data_for_optimize_flh=False,
+                    **settings,
                 )
                 res_list.append(res_single)
             except Exception as exc:
@@ -331,12 +360,12 @@ def calculate_results_list_blue(
                 keep="last",
             )
             try:
-                res_single = calculate_results_single(
+                res_single = calculate_costs_cached(
                     api,
-                    settings,
                     user_data=user_data,
                     optimize_flh=False,
                     use_user_data_for_optimize_flh=False,
+                    **settings,
                 )
 
                 def get_label(change_factor, original_value):

--- a/app/tab_blue_costs_comparison.py
+++ b/app/tab_blue_costs_comparison.py
@@ -46,8 +46,8 @@ def aggregate_green_results(
     _api: PtxboaAPI,
     scenarios: list[ScenarioType],
     import_country: TargetCountryNameType,
-    output_product: OutputUnitType,
-    output_unit: str,
+    output_product: str,
+    output_unit: OutputUnitType,
     green_param_set: Literal["restricted", "complete"] = "restricted",
 ):
     output_product_equivalents = {
@@ -120,8 +120,8 @@ def aggregate_green_results(
                 costs.append(
                     calculate_costs_cached(
                         _api,
-                        user_data=None,  # we do not respct user data
-                        optimize_flh=False,  # TODO @joAschauer set to True when ready
+                        user_data=None,  # we do not respect user data here
+                        optimize_flh=True,
                         use_user_data_for_optimize_flh=False,
                         scenario=scenario,
                         country=import_country,
@@ -173,7 +173,9 @@ def make_figure(
     green_lower_bound,
     green_upper_bound,
     blue,
-    output_product,
+    output_product: str,
+    xaxis_title: str,
+    yaxis_title: str,
 ) -> go.Figure:
     GREEN_COLOR = "#2fac66"
     BLUE_COLOR = "#1E83B3"
@@ -276,8 +278,8 @@ def make_figure(
     fig.update_layout(
         hovermode="x unified",
         legend_traceorder="reversed",
-        xaxis={"title": {"text": "Scenario"}},
-        yaxis={"title": {"text": st.session_state["output_unit"]}},
+        xaxis={"title": {"text": xaxis_title}},
+        yaxis={"title": {"text": yaxis_title}},
     )
     return fig
 
@@ -308,5 +310,7 @@ def content_costs_comparison(api):
             green_upper_bound="75%",
             blue="blue_Total",
             output_product=st.session_state["output_product"],
+            xaxis_title="Scenario",
+            yaxis_title=st.session_state["output_unit"],
         )
         st.plotly_chart(fig)

--- a/app/tab_blue_costs_comparison.py
+++ b/app/tab_blue_costs_comparison.py
@@ -1,0 +1,312 @@
+"""
+Tab in the blue app which compares blue PtX vs. green PtX costs.
+
+The blue PtX costs are calculated from the current settings.
+The green PtX costs are an median, 25th, and 75th percentiles for costs of
+all export countries and chains that have the current product as output product.
+"""
+
+import itertools
+import logging
+from typing import Literal
+
+import pandas as pd
+import plotly.graph_objects as go
+import streamlit as st
+
+from app.ptxboa_functions import (
+    calculate_costs_cached,
+    calculate_results_list_blue,
+)
+from ptxboa.api import PtxboaAPI
+from ptxboa.static import OutputUnitType, ScenarioType, TargetCountryNameType
+
+
+def product_dict(**kwargs):
+    """Yield the cartesian product of a dictionary of lists.
+
+    https://stackoverflow.com/a/5228294
+
+    >>> list(product_dict(sting=["a", "b", "c"], number=[1, 2]))
+
+    [{'sting': 'a', 'number': 1},
+    {'sting': 'a', 'number': 2},
+    {'sting': 'b', 'number': 1},
+    {'sting': 'b', 'number': 2},
+    {'sting': 'c', 'number': 1},
+    {'sting': 'c', 'number': 2}]
+    """
+    keys = kwargs.keys()
+    for instance in itertools.product(*kwargs.values()):
+        yield dict(zip(keys, instance))
+
+
+@st.cache_data(show_spinner=False)
+def aggregate_green_results(
+    _api: PtxboaAPI,
+    scenarios: list[ScenarioType],
+    import_country: TargetCountryNameType,
+    output_product: OutputUnitType,
+    output_unit: str,
+    green_param_set: Literal["restricted", "complete"] = "restricted",
+):
+    output_product_equivalents = {
+        "Ammonia": "NH3-L",
+        "Green Iron": "DRI-S",
+        "FT e-fuels": "CHX-L",
+        "Hydrogen": "H2-G",
+        "Methanol": "CH3OH-L",
+    }
+
+    if output_product not in output_product_equivalents:
+        return None
+
+    if green_param_set == "complete":
+        # complete parame set is too slow without caching.
+        dimensions = {
+            "transport": _api.get_dimension("transport").index.tolist(),
+            "ship_own_fuel": [True, False],
+            "secproc_water": _api.get_dimension("secproc_water").index.tolist(),
+            "secproc_co2": _api.get_dimension("secproc_co2").index.tolist(),
+            "res_gen": _api.get_dimension("res_gen").index.tolist(),
+            "region": (
+                _api.get_dimension("region")
+                .loc[_api.get_dimension("region")["subregion_code"] == ""]
+                .index.to_list()
+            ),
+            "chain": (
+                _api.get_dimension("chain")
+                .loc[
+                    _api.get_dimension("chain")["FLOW_OUT"]
+                    == output_product_equivalents[output_product]
+                ]
+                .index.tolist()
+            ),
+        }
+
+    elif green_param_set == "restricted":
+        dimensions = {
+            "transport": ["Pipeline"],
+            "ship_own_fuel": [True],
+            "secproc_water": ["Specific costs"],
+            "secproc_co2": ["Specific costs"],
+            "res_gen": ["Wind-PV-Hybrid"],
+            "region": (
+                _api.get_dimension("region")
+                .loc[_api.get_dimension("region")["subregion_code"] == ""]
+                .index.to_list()
+            ),
+            "chain": (
+                _api.get_dimension("chain")
+                .loc[
+                    _api.get_dimension("chain")["FLOW_OUT"]
+                    == output_product_equivalents[output_product]
+                ]
+                .index.tolist()
+            ),
+        }
+    else:
+        raise ValueError(f"Unknown {green_param_set=}")
+
+    stats = []
+    i = 0
+    for scenario in scenarios:
+        costs = []
+        for param_set in product_dict(**dimensions):
+            i += 1
+            if i % 100 == 0:
+                logging.info(i)
+            try:
+                costs.append(
+                    calculate_costs_cached(
+                        _api,
+                        user_data=None,  # we do not respct user data
+                        optimize_flh=False,  # TODO @joAschauer set to True when ready
+                        use_user_data_for_optimize_flh=False,
+                        scenario=scenario,
+                        country=import_country,
+                        output_unit=output_unit,
+                        **param_set,
+                    )["values"].sum()
+                )
+            except Exception as exc:
+                logging.info(f"could not get data: {exc}")
+        stats.append(
+            pd.Series(costs)
+            .describe()
+            .rename("values")
+            .rename_axis(index="metric")
+            .reset_index()
+            .assign(scenario=scenario)
+        )
+
+    return pd.concat(stats).pivot(columns="metric", index="scenario", values="values")
+
+
+def get_data(
+    api, scenarios: list[ScenarioType], import_country, output_product, output_unit
+):
+    with st.spinner("Calculating green results"):
+        costs_green = aggregate_green_results(
+            api,
+            scenarios=scenarios,
+            import_country=import_country,
+            output_product=output_product,
+            output_unit=output_unit,
+        )
+
+    costs_blue = calculate_results_list_blue(
+        api,
+        parameter_to_change="scenario",
+        parameter_list=scenarios,
+        apply_user_data=True,
+        override_session_state=None,
+    ).add_prefix("blue_")
+
+    return pd.concat([costs_green, costs_blue], axis=1).reset_index()
+
+
+def make_figure(
+    data: pd.DataFrame,
+    x,
+    green_median,
+    green_lower_bound,
+    green_upper_bound,
+    blue,
+    output_product,
+) -> go.Figure:
+    GREEN_COLOR = "#2fac66"
+    BLUE_COLOR = "#1E83B3"
+    BOUNDS_LW = 0.7
+
+    def _add_invisible_trace(fig, df, x, y):
+        fig.add_trace(
+            go.Scatter(
+                x=df[x],
+                y=df[y],
+                fill=None,
+                mode="lines",
+                line_color="rgba(0,0,0,0)",
+                showlegend=False,
+                hoverinfo="skip",
+            )
+        )
+
+    def _add_line(
+        fig,
+        df,
+        x,
+        y,
+        line_color,
+        legend_label,
+        hover_label,
+        showlegend,
+        fill,
+        **kwargs,
+    ):
+        fig.add_trace(
+            go.Scatter(
+                x=df[x],
+                y=df[y],
+                fill=fill,
+                mode="lines",
+                line_color=line_color,
+                showlegend=showlegend,
+                name=legend_label,
+                hoverinfo="text",
+                hovertext=[f"{hover_label}: {v}" for v in df[y]],
+                **kwargs,
+            )
+        )
+
+    fig = go.Figure()
+
+    # fill='tonexty' always references trace which was added before
+    _add_invisible_trace(fig=fig, df=data, x=x, y=green_median)
+    _add_line(
+        fig=fig,
+        df=data,
+        legend_label=f"25th - 75th percentile green {output_product}",
+        hover_label=f"75th percentile green {output_product}",
+        x=x,
+        y=green_upper_bound,
+        line_color=GREEN_COLOR,
+        line={"width": BOUNDS_LW},
+        fill="tonexty",
+        showlegend=True,
+    )
+
+    _add_line(
+        fig=fig,
+        df=data,
+        legend_label=f"Median green {output_product}",
+        hover_label=f"Median green {output_product}",
+        x=x,
+        y=green_median,
+        line_color=GREEN_COLOR,
+        fill=None,
+        showlegend=True,
+    )
+
+    _add_line(
+        fig=fig,
+        df=data,
+        legend_label=f"25th - 75th percentile green {output_product}",
+        hover_label=f"25th percentile green {output_product}",
+        x=x,
+        y=green_lower_bound,
+        line_color=GREEN_COLOR,
+        line={"width": BOUNDS_LW},
+        fill="tonexty",
+        showlegend=False,
+    )
+
+    _add_line(
+        fig=fig,
+        df=data,
+        legend_label=f"Blue {output_product}",
+        hover_label=f"Blue {output_product}",
+        x=x,
+        y=blue,
+        line_color=BLUE_COLOR,
+        fill=None,
+        showlegend=True,
+    )
+
+    fig.update_layout(
+        hovermode="x unified",
+        legend_traceorder="reversed",
+        xaxis={"title": {"text": "Scenario"}},
+        yaxis={"title": {"text": st.session_state["output_unit"]}},
+    )
+    return fig
+
+
+def content_costs_comparison(api):
+    with st.popover("*Help*", width="stretch"):
+        st.markdown("User data not used to optimize FLH for green costs.")
+
+    with st.container(border=True):
+        costs = get_data(
+            api,
+            scenarios=["2030 (medium)", "2040 (medium)"],
+            import_country=st.session_state["country"],
+            output_product=st.session_state["output_product"],
+            output_unit=st.session_state["output_unit"],
+        )
+        title_string = (
+            f"Cost of importing "
+            f"{st.session_state['output_product']} to "
+            f"{st.session_state['country']}"
+        )
+        st.subheader(title_string)
+        fig = make_figure(
+            costs,
+            x="scenario",
+            green_median="50%",
+            green_lower_bound="25%",
+            green_upper_bound="75%",
+            blue="blue_Total",
+            output_product=st.session_state["output_product"],
+        )
+        st.plotly_chart(fig)

--- a/ptxboa_blue.py
+++ b/ptxboa_blue.py
@@ -6,6 +6,7 @@ import streamlit_antd_components as sac
 from app.layout_elements import display_footer
 from app.sidebar import make_sidebar_blue
 from app.tab_blue_costs import content_costs
+from app.tab_blue_costs_comparison import content_costs_comparison
 from app.user_data import display_user_changes
 from app.user_data_from_file import download_user_data, upload_user_data
 from ptxboa import DEFAULT_CACHE_DIR, DEFAULT_DATA_DIR
@@ -46,6 +47,7 @@ with st.container():
 tabs = (
     "Info",
     "Costs",
+    "Costs Comparison",
     "Emissions",
     "Input data",
 )
@@ -84,12 +86,16 @@ st.session_state["chain"] = "Ammonia (AEL)"
 st.session_state["scenario"] = "2040 (medium)"
 st.session_state["secproc_water"] = "Specific costs"
 st.session_state["subregion"] = None
+st.session_state["output_product"] = "Ammonia"
 
 if st.session_state[st.session_state["tab_key"]] == "Info":
     st.text("Blue PtX Info")
 
 if st.session_state[st.session_state["tab_key"]] == "Costs":
     content_costs(api)
+
+if st.session_state[st.session_state["tab_key"]] == "Costs Comparison":
+    content_costs_comparison(api)
 
 if st.session_state[st.session_state["tab_key"]] == "Emissions":
     st.markdown(


### PR DESCRIPTION
Introduces a new tab with a figure that shows costs vs. time (i.e. scenario) for blue and green selected PtX product.

Blue costs are based on the current settings in the sidebar (import and export country, output product, reformer etc.)

Green costs are calculated as statistics over a range of green parameter sets: all source regions, all chains that produce the same output product as selected in the sidebar. Right now, we need a restricted parameter set since the runtime is too slow when too many dimensions are changed. Therefore these dimensions are fixed: `"transport", "ship_own_fuel", "secproc_water", "secproc_co2", "res_gen"`
 
