### PR TITLE
add used transport settings to result tables

### DIFF
--- a/ptxboa/api.py
+++ b/ptxboa/api.py
@@ -222,7 +222,7 @@ class PtxboaAPI:
             data_handler=data_handler,
         )
 
-        # add user settings
+        # add used settings
         for df in [
             ptxcalc_result.df_results_cost,
             ptxcalc_result.df_results_emissions_e_g_co2e,
@@ -235,7 +235,8 @@ class PtxboaAPI:
             df["res_gen"] = res_gen
             df["region"] = region
             df["country"] = country
-            df["transport"] = transport
+            df["transport"] = chain_def.transport
+            df["ship_own_fuel"] = chain_def.ship_own_fuel
 
         metadata = {"flh_opt_hash": data.get("flh_opt_hash")}  # does not always exist
 


### PR DESCRIPTION
In the sidebar you can set the option `allow_pipeline`. If transport via pipeline is not possible (product not transportable via pipeline or distance not feasible), the the backend silently switches to transport via ship and sets `ship_own_fuel=False`. In the result dataframes, transport is then still set to pipeline, even though ship was used. It would be better to return the actually used `transport` and `ship_own_fuel` settings

I think this can be done by passing the `transport` and `ship_own_fuel` from ChainDef to the output.